### PR TITLE
Fix PDF break, margin, twitter emojis

### DIFF
--- a/twindle-cli/renderer/pdf/render-template.js
+++ b/twindle-cli/renderer/pdf/render-template.js
@@ -1,6 +1,6 @@
-const { readFile } = require("fs").promises;
+const { readFile, writeFile } = require("fs").promises;
 const hbs = require("handlebars");
-const { fixLineBreaks } = require("../../twitter/utils/tweet-utils");
+const { tmpdir } = require("os");
 
 /**
  * Renders the html template with the given data and returns the html string
@@ -8,10 +8,7 @@ const { fixLineBreaks } = require("../../twitter/utils/tweet-utils");
  * @param {string} templateName
  */
 async function renderTemplate(data, templateName) {
-  const html = await readFile(
-    `${__dirname}/templates/${templateName}.hbs`,
-    "utf-8"
-  );
+  const html = await readFile(`${__dirname}/templates/${templateName}.hbs`, "utf-8");
 
   // creates the Handlebars template object
   const template = hbs.compile(html, {
@@ -20,6 +17,8 @@ async function renderTemplate(data, templateName) {
 
   // renders the html template with the given data
   const rendered = template(data);
+
+  await writeFile(`${tmpdir()}/hello.html`, rendered, "utf-8");
 
   return rendered;
 }

--- a/twindle-cli/renderer/pdf/templates/Thread.hbs
+++ b/twindle-cli/renderer/pdf/templates/Thread.hbs
@@ -21,11 +21,17 @@
 
   ul li {
     margin: 20px;
+    page-break-inside: avoid;
+    page-break-after: always;
+
+    width: 100%;
   }
 
   .tweetContainer {
     display: flex;
     flex-direction: column;
+
+    width: 100%;
   }
 
   .tweetContainer * {
@@ -63,21 +69,28 @@
     font-style: italic;
     color: rgb(45, 45, 45);
   }
+
+  img.emoji {
+    height: 1em;
+    width: 1em;
+    margin: 0 .05em 0 .1em;
+    vertical-align: -0.1em;
+  }
 </style>
 
 <h1 id="title">Twindle Thread</h1>
 <div class="tweetContainer">
-    <div class="header">
-      <img src="{{common.user.profile_image_url}}" alt="{{common.user.username}}" />
-      <div>
-        <h3>{{common.user.name}} - <span>@{{common.user.username}}</span></h3>
-        <p><span>{{common.created_at}}</span></p>
-        <p><span>{{common.user.description}}</span></p>
-        <p><span>Number of tweets: {{common.count}}</span></p>
-      </div>
+  <div class="header">
+    <img src="{{common.user.profile_image_url}}" alt="{{common.user.username}}" />
+    <div>
+      <h3>{{common.user.name}} - <span>@{{common.user.username}}</span></h3>
+      <p><span>{{common.created_at}}</span></p>
+      <p><span>{{common.user.description}}</span></p>
+      <p><span>Number of tweets: {{common.count}}</span></p>
     </div>
+  </div>
 </div>
-  
+
 <ul>
   {{!-- uses the twit mock object from mock API --}}
   {{#each thread}}

--- a/twindle-cli/twitter/utils/tweet-utils.js
+++ b/twindle-cli/twitter/utils/tweet-utils.js
@@ -34,7 +34,10 @@ const createCustomTweet = (tweet_object, user_object) => {
   return {
     id: tweet_object.id,
     createdAt: format(new Date(tweet_object.created_at), "MMM d, yyyy  h:mm aaaa"),
-    tweet: twemoji.parse(fixLineBreaks(tweet_object.text)),
+    tweet: twemoji.parse(fixLineBreaks(tweet_object.text), {
+      folder: "svg",
+      ext: ".svg",
+    }),
   };
 };
 


### PR DESCRIPTION
## Description
- Original emojis replaced with Twitter Emojis
- Weird Margin and centering issue fixed
- Fixed content break when PDF wraps to the other page
- Every build produces a `hello.html` in the device's `temp` folder, where it can be inspected

Check out `simon.pdf` in TwindleLibrary folder

## Attach Screenshot
![image](https://user-images.githubusercontent.com/47742487/98216508-2bb44f00-1f6f-11eb-9122-0d6e440c892b.png)

