### PR TITLE
Added Puppeteer WebScraping Integration

### DIFF
--- a/twindle-cli/cli.js
+++ b/twindle-cli/cli.js
@@ -1,45 +1,57 @@
-const yargs = require("yargs");
-const { createLibraryIfNotExists } = require("./utils/library");
+const yargs = require('yargs');
+const { createLibraryIfNotExists } = require('./utils/library');
 
 const getCommandlineArgs = (processArgv) =>
   yargs(processArgv)
     .usage(
-      "Usage: -i <tweet id> -f <file format> -o <filename> -s <send to kindle email>"
+      'Usage: -i <tweet id> -f <file format> -o <filename> -s <send to kindle email>'
     )
     .option({
       i: {
-        alias: "tweetId",
+        alias: 'tweetId',
         demandOption: false,
         describe: "First tweet's tweet id in of the twitter thread",
-        type: "string",
+        type: 'string',
       },
       f: {
-        alias: "format",
+        alias: 'format',
         demandOption: false,
-        describe: "Output file format",
-        choices: ["mobi", "epub", "pdf"],
-        type: "string",
-        default: "pdf",
+        describe: 'Output file format',
+        choices: ['mobi', 'epub', 'pdf'],
+        type: 'string',
+        default: 'pdf',
       },
       o: {
-        alias: "outputFilename",
+        alias: 'outputFilename',
         demandOption: false,
-        describe: "Filename for the output file",
-        type: "string",
-        default: "twindle-thread.pdf",
+        describe: 'Filename for the output file',
+        type: 'string',
+        default: 'twindle-thread.pdf',
       },
       s: {
-        alias: "kindleEmail",
+        alias: 'kindleEmail',
         demandOption: false,
         describe:
-          "The email of the kindle device, you wish to send the created pdf",
-        type: "string",
+          'The email of the kindle device, you wish to send the created pdf',
+        type: 'string',
       },
       m: {
-        alias: "mock",
+        alias: 'mock',
         demandOption: false,
-        describe: "If set, will run in mock mode",
-        type: "boolean",
+        describe: 'If set, will run in mock mode',
+        type: 'boolean',
+      },
+      u: {
+        alias: 'url',
+        demandOption: false,
+        describe: "First tweet's tweet url of the twitter thread",
+        type: 'string',
+      },
+      p: {
+        alias: 'shouldUsePuppeteer',
+        demandOption: false,
+        describe: 'Should use Puppeteer or not',
+        type: 'boolean',
       },
     }).argv;
 

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -1,11 +1,12 @@
 // Entry program
-require("./helpers/logger");
-require("dotenv").config();
-const { getCommandlineArgs, prepareCli } = require("./cli");
-const Renderer = require("./renderer");
-const { getTweetsFromTweetId } = require("./twitter");
-const { getOutputFilePath } = require("./utils/path");
-const { sendToKindle } = require("./utils/send-to-kindle");
+require('./helpers/logger');
+require('dotenv').config();
+const { getCommandlineArgs, prepareCli } = require('./cli');
+const Renderer = require('./renderer');
+const { getTweetsFromTweetId } = require('./twitter');
+const { getOutputFilePath } = require('./utils/path');
+const { sendToKindle } = require('./utils/send-to-kindle');
+const { getTweet } = require('./twitter-puppeteer');
 
 async function main() {
   prepareCli();
@@ -16,12 +17,17 @@ async function main() {
     tweetId,
     kindleEmail,
     mock,
+    url,
+    shouldUsePuppeteer,
   } = getCommandlineArgs(process.argv);
 
   try {
     // this next line is wrong
-    let tweets = require("./twitter/twitter_responses/response-version2-tweetthread.json");
-    if (!mock) tweets = await getTweetsFromTweetId(tweetId);
+    let tweets = require('./twitter/twitter_responses/response-version2-tweetthread.json');
+    if (!mock) {
+      if (shouldUsePuppeteer) tweets = await getTweet(url);
+      else tweets = await getTweetsFromTweetId(tweetId);
+    }
 
     const outputFilePath = getOutputFilePath(outputFilename);
     await Renderer.render(tweets, format, outputFilePath);

--- a/twindle-cli/renderer/pdf/templates/Thread.hbs
+++ b/twindle-cli/renderer/pdf/templates/Thread.hbs
@@ -26,7 +26,7 @@
 
   ul li {
     margin: 0;
-    
+
     page-break-before: always;
     page-break-inside: avoid;
     page-break-after: always;
@@ -88,6 +88,8 @@
 </style>
 
 <h1 id="title">Twindle Thread</h1>
+
+{{#if common}}
 <div class="tweetContainer">
   <div class="header">
     <img src="{{common.user.profile_image_url}}" alt="{{common.user.username}}" />
@@ -99,6 +101,8 @@
     </div>
   </div>
 </div>
+{{/if}}
+
 
 <ul>
   {{!-- uses the twit mock object from mock API --}}
@@ -111,4 +115,3 @@
   {{/each}}
 
 </ul>
-

--- a/twindle-cli/twitter-puppeteer/index.js
+++ b/twindle-cli/twitter-puppeteer/index.js
@@ -1,0 +1,19 @@
+const puppeteer = require('puppeteer');
+const getTweet = async (pageUrl) => {
+  const browser = await puppeteer.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.goto(pageUrl, {
+    waitUntil: 'networkidle0',
+  });
+  const tweets = await page.evaluate(() => {
+    const tweetNodes = Array.from(
+      document.querySelectorAll('div[lang]:not([lang=""])')
+    );
+    const data = tweetNodes.map((node) => ({
+      tweet: node.innerText,
+    }));
+    return data;
+  });
+  return { data: tweets };
+};
+module.exports = { getTweet };


### PR DESCRIPTION
## Description

Added Puppeteer WebScraping Integration. Now you can use -u for url and -p for using puppeteer.

## Attach Screenshot

[twindle-thread.pdf](https://github.com/twindle-co/twindle/files/5495752/twindle-thread.pdf)

![Tweet](https://user-images.githubusercontent.com/5336488/98270877-56c19180-1fb5-11eb-8588-89be15a97229.PNG)


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
