### PR TITLE
Fix puppeteer viewport issues, now only tweet ID can be used. Eliminate -u flag

### DIFF
--- a/twindle-cli/cli.js
+++ b/twindle-cli/cli.js
@@ -41,12 +41,6 @@ const getCommandlineArgs = (processArgv) =>
         describe: 'If set, will run in mock mode',
         type: 'boolean',
       },
-      u: {
-        alias: 'url',
-        demandOption: false,
-        describe: "First tweet's tweet url of the twitter thread",
-        type: 'string',
-      },
       p: {
         alias: 'shouldUsePuppeteer',
         demandOption: false,

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -1,6 +1,5 @@
 // Entry program
-
-require("./helpers/logger");
+// require("./helpers/logger");
 require("dotenv").config();
 const { getCommandlineArgs, prepareCli } = require("./cli");
 const Renderer = require("./renderer");
@@ -18,7 +17,6 @@ async function main() {
     tweetId,
     kindleEmail,
     mock,
-    url,
     shouldUsePuppeteer,
   } = getCommandlineArgs(process.argv);
 

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -1,13 +1,13 @@
 // Entry program
 
-require('./helpers/logger');
-require('dotenv').config();
-const { getCommandlineArgs, prepareCli } = require('./cli');
-const Renderer = require('./renderer');
-const { getTweetsFromTweetId } = require('./twitter');
-const { getOutputFilePath } = require('./utils/path');
-const { sendToKindle } = require('./utils/send-to-kindle');
-const { getTweet } = require('./twitter-puppeteer');
+require("./helpers/logger");
+require("dotenv").config();
+const { getCommandlineArgs, prepareCli } = require("./cli");
+const Renderer = require("./renderer");
+const { getTweetsFromTweetId } = require("./twitter");
+const { getOutputFilePath } = require("./utils/path");
+const { sendToKindle } = require("./utils/send-to-kindle");
+const { getTweet } = require("./twitter-puppeteer");
 
 async function main() {
   prepareCli();
@@ -24,13 +24,14 @@ async function main() {
 
   try {
     // this next line is wrong
-    let tweets = require('./twitter/twitter_responses/response-version2-tweetthread.json');
+    let tweets = require("./twitter/twitter_responses/response-version2-tweetthread.json");
     if (!mock) {
-      if (shouldUsePuppeteer) tweets = await getTweet(url);
+      if (shouldUsePuppeteer) tweets = await getTweet(tweetId);
       else tweets = await getTweetsFromTweetId(tweetId);
     }
 
     const outputFilePath = getOutputFilePath(outputFilename);
+
     await Renderer.render(tweets, format, outputFilePath);
 
     if (kindleEmail) {

--- a/twindle-cli/twitter-puppeteer/index.js
+++ b/twindle-cli/twitter-puppeteer/index.js
@@ -1,4 +1,5 @@
 const puppeteer = require("puppeteer");
+const { waitFor } = require("../utils/helpers");
 
 /**
  * Get tweets(even older than 7 days) using puppeteer
@@ -9,7 +10,7 @@ const getTweet = async (tweetID) => {
 
   try {
     // Modify this variable to control the size of viewport
-    const factor = 0.3;
+    const factor = 0.1;
     const height = Math.floor(2000 / factor);
     const width = Math.floor(1700 / factor);
 
@@ -27,6 +28,8 @@ const getTweet = async (tweetID) => {
     await page.goto(pageURL, {
       waitUntil: "networkidle2",
     });
+
+    await waitFor(4000);
 
     // page.on("popup", (e) => console.log(e));
 

--- a/twindle-cli/twitter-puppeteer/index.js
+++ b/twindle-cli/twitter-puppeteer/index.js
@@ -1,19 +1,56 @@
-const puppeteer = require('puppeteer');
-const getTweet = async (pageUrl) => {
-  const browser = await puppeteer.launch({ headless: true });
-  const page = await browser.newPage();
-  await page.goto(pageUrl, {
-    waitUntil: 'networkidle0',
-  });
-  const tweets = await page.evaluate(() => {
-    const tweetNodes = Array.from(
-      document.querySelectorAll('div[lang]:not([lang=""])')
-    );
-    const data = tweetNodes.map((node) => ({
-      tweet: node.innerText,
-    }));
-    return data;
-  });
-  return { data: tweets };
+const puppeteer = require("puppeteer");
+
+/**
+ * Get tweets(even older than 7 days) using puppeteer
+ * @param {string} tweetID
+ */
+const getTweet = async (tweetID) => {
+  const pageURL = `https://twitter.com/anyone/status/${tweetID}`;
+
+  try {
+    // Modify this variable to control the size of viewport
+    const factor = 0.3;
+    const height = Math.floor(2000 / factor);
+    const width = Math.floor(1700 / factor);
+
+    const browser = await puppeteer.launch({
+      headless: false,
+      defaultViewport: {
+        width,
+        height,
+      },
+      args: [`--force-device-scale-factor=${factor}`, `--window-size=${width},${height}`],
+    });
+
+    const page = await browser.newPage();
+
+    await page.goto(pageURL, {
+      waitUntil: "networkidle2",
+    });
+
+    // page.on("popup", (e) => console.log(e));
+
+    // await page.waitForNavigation({ waitUntil: "domcontentloaded" });
+
+    const session = await page.target().createCDPSession();
+    await session.send("Emulation.setPageScaleFactor", {
+      pageScaleFactor: 0.5, // 400%
+    });
+
+    const tweets = await page.evaluate(() => {
+      const tweetNodes = Array.from(document.querySelectorAll('div[lang]:not([lang=""])'));
+      const data = tweetNodes.map((node) => ({
+        tweet: node.innerText,
+      }));
+      return data;
+    });
+
+    console.log(tweets);
+
+    return { data: tweets };
+  } catch (e) {
+    console.error(e);
+  }
 };
+
 module.exports = { getTweet };

--- a/twindle-cli/utils/helpers.js
+++ b/twindle-cli/utils/helpers.js
@@ -1,0 +1,5 @@
+/**
+ * Wait for `ms` amount of milliseconds
+ * @param {number} ms 
+ */
+const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/twindle-cli/utils/helpers.js
+++ b/twindle-cli/utils/helpers.js
@@ -1,5 +1,7 @@
 /**
  * Wait for `ms` amount of milliseconds
- * @param {number} ms 
+ * @param {number} ms
  */
 const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+module.exports = { waitFor };


### PR DESCRIPTION
## Description 
- Fix puppeteer viewport - Can be changed using a single `factor` variable. See `twitter-puppeteer/index.js` Line 12
- No need to pass URl with `-u` now. 

```bash
node . -i 1324263512621883393 -o simon -p
```

works perfectly.

## Screenshots

Zoomed out
![image](https://user-images.githubusercontent.com/47742487/98332846-814b3300-2025-11eb-8b36-8cbf557cbf6c.png)

PDF itself(Needs more work, includes non-thread replies): 
[naval.pdf](https://github.com/twindle-co/twindle/files/5499486/naval.pdf)


Closes #645 

More stuff showing and filtering depends on @vijaya-bhaskar now.

