### PR TITLE
Error while trying to retrieve a tweet

### DIFF
--- a/twindle-cli/twitter/utils/process-tweet-entities.js
+++ b/twindle-cli/twitter/utils/process-tweet-entities.js
@@ -77,6 +77,9 @@ function renderMedia(tweetObj) {
  */
 function renderOutsiderLinks(tweetObj) {
   /** @type {any[]} */
+  
+  if(!tweetObj.entities) return tweetObj;
+
   let urlObjs = tweetObj.entities.urls;
 
   if (!urlObjs) return tweetObj;
@@ -131,6 +134,8 @@ function renderOutsiderLinks(tweetObj) {
  */
 function fixUserDescription(tweets) {
   // console.log(tweets.common.user.entities);
+  if(!tweets.common.user.entities) return tweets;
+  
   const descriptionURLs =
     tweets.common.user.entities.description && tweets.common.user.entities.description.urls;
 


### PR DESCRIPTION

## Description
If entities attribute is missing on the twitter response, then there was an error. Happened while trying to retrieve
[Vijaya Bhaskar's tweet](https://twitter.com/vijaya_bhaskar_/status/1324626012265734144)


## Attach Screenshot


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
