### PR TITLE
Make -s optional, defaults to env, otherwise throw error | Cleaner errors

### DIFF
--- a/twindle-cli/cli.js
+++ b/twindle-cli/cli.js
@@ -1,50 +1,51 @@
-const yargs = require('yargs');
-const { createLibraryIfNotExists } = require('./utils/library');
+const yargs = require("yargs");
+const { createLibraryIfNotExists } = require("./utils/library");
 
 const getCommandlineArgs = (processArgv) =>
   yargs(processArgv)
     .usage(
-      'Usage: -i <tweet id> -f <file format> -o <filename> -s <send to kindle email>'
+      "Usage: -i <tweet id> -f <file format> -o <filename> -s <send to kindle email| Optionally pass kindle email here>"
     )
     .option({
       i: {
-        alias: 'tweetId',
+        alias: "tweetId",
         demandOption: false,
         describe: "First tweet's tweet id in of the twitter thread",
-        type: 'string',
+        type: "string",
       },
       f: {
-        alias: 'format',
+        alias: "format",
         demandOption: false,
-        describe: 'Output file format',
-        choices: ['mobi', 'epub', 'pdf'],
-        type: 'string',
-        default: 'pdf',
+        describe: "Output file format",
+        choices: ["mobi", "epub", "pdf"],
+        type: "string",
+        default: "pdf",
       },
       o: {
-        alias: 'outputFilename',
+        alias: "outputFilename",
         demandOption: false,
-        describe: 'Filename for the output file',
-        type: 'string',
+        describe: "Filename for the output file",
+        type: "string",
       },
       s: {
-        alias: 'kindleEmail',
+        alias: "sendKindleEmail",
         demandOption: false,
         describe:
-          'The email of the kindle device, you wish to send the created pdf',
-        type: 'string',
+          "Send document to your kindle email. Optionally pass kindle email here if not configured in .env file",
+        type: "string",
+        default: process.env.KINDLE_EMAIL
       },
       m: {
-        alias: 'mock',
+        alias: "mock",
         demandOption: false,
-        describe: 'If set, will run in mock mode',
-        type: 'boolean',
+        describe: "If set, will run in mock mode",
+        type: "boolean",
       },
       p: {
-        alias: 'shouldUsePuppeteer',
+        alias: "shouldUsePuppeteer",
         demandOption: false,
-        describe: 'Should use Puppeteer or not',
-        type: 'boolean',
+        describe: "Should use Puppeteer or not",
+        type: "boolean",
       },
     }).argv;
 

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -9,6 +9,7 @@ const { sendToKindle } = require("./utils/send-to-kindle");
 const { getTweet } = require("./twitter-puppeteer");
 const { UserError } = require("./helpers/error");
 const { red } = require("kleur");
+const { isValidEmail } = require("./utils/helpers");
 
 async function main() {
   prepareCli();
@@ -48,13 +49,20 @@ async function main() {
           "Pass your kindle email address with -s or configure it in the .env file"
         );
 
+      if (!isValidEmail(kindleEmail)) {
+        const errorMessage = !!process.argv[process.argv.indexOf("-s") + 1]
+          ? "Enter a valid email address"
+          : "Kindle Email configured in .env file is invalid";
+
+        throw new UserError("invalid-email", errorMessage);
+      }
+
       console.devLog("sending to kindle", kindleEmail);
       await sendToKindle(kindleEmail, outputFilePath);
     }
   } catch (e) {
-
     // Show stack errors if Dev logs are enabled in `.env` file
-    if (process.env.DEV) {
+    if (process.env.DEV === "true") {
       console.log(e);
     } else {
       console.error(`${red(e.name)}: ${e.message}`);

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -47,12 +47,18 @@ async function main() {
           "empty-kindle-email",
           "Pass your kindle email address with -s or configure it in the .env file"
         );
-        
+
       console.devLog("sending to kindle", kindleEmail);
       await sendToKindle(kindleEmail, outputFilePath);
     }
   } catch (e) {
-    console.error(`${red(e.name)}: ${e.message}`);
+
+    // Show stack errors if Dev logs are enabled in `.env` file
+    if (process.env.DEV) {
+      console.log(e);
+    } else {
+      console.error(`${red(e.name)}: ${e.message}`);
+    }
   }
 
   // If not for this line, the script never finishes

--- a/twindle-cli/utils/helpers.js
+++ b/twindle-cli/utils/helpers.js
@@ -4,4 +4,13 @@
  */
 const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-module.exports = { waitFor };
+/**
+ * Validate email
+ * @param {string} email
+ */
+function isValidEmail(email) {
+  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(String(email).toLowerCase());
+}
+
+module.exports = { waitFor, isValidEmail };


### PR DESCRIPTION
## Description

### Cleaned up error messages
Error messages are much cleaner
![image](https://user-images.githubusercontent.com/47742487/98454061-59271580-2186-11eb-83c4-f6c735deec9e.png)

The original stack based errors can be enabled by setting `DEV=true` in `.env` file

Closes #666 

### Better

```bash
node . -i 1325057458633498624 -o twindle-discussion -s emailaddress
```
sends to `emailaddress` specified next to -s

```bash
node . -i 1325057458633498624 -o twindle-discussion -s 
```
sends to `KINDLE_EMAIL` configured into the `.env` file.

If no email in `.env` file itself, then throw errors

Closes #675 
