### PR TITLE
Scraping logic included in the new refactored Twitter API code

### DIFF
--- a/twindle-cli/cli.js
+++ b/twindle-cli/cli.js
@@ -28,11 +28,12 @@ const getCommandlineArgs = (processArgv) =>
         type: 'string',
       },
       s: {
-        alias: 'kindleEmail',
+        alias: "sendKindleEmail",
         demandOption: false,
         describe:
-          'The email of the kindle device, you wish to send the created pdf',
-        type: 'string',
+          "Send document to your kindle email. Optionally pass kindle email here if not configured in .env file",
+        type: "string",
+        default: process.env.KINDLE_EMAIL
       },
       m: {
         alias: 'mock',

--- a/twindle-cli/twitter-puppeteer/index.js
+++ b/twindle-cli/twitter-puppeteer/index.js
@@ -5,55 +5,86 @@ const { waitFor } = require("../utils/helpers");
  * Get tweets(even older than 7 days) using puppeteer
  * @param {string} tweetID
  */
-const getTweet = async (tweetID) => {
+const getTweetIDs = async (tweetID) => {
   const pageURL = `https://twitter.com/anyone/status/${tweetID}`;
 
-  try {
-    // Modify this variable to control the size of viewport
-    const factor = 0.1;
-    const height = Math.floor(2000 / factor);
-    const width = Math.floor(1700 / factor);
+  // Modify this variable to control the size of viewport
+  const factor = 0.2;
+  const height = Math.floor(2000 / factor);
+  const width = Math.floor(1700 / factor);
 
-    const browser = await puppeteer.launch({
-      headless: true,
-      defaultViewport: {
-        width,
-        height,
-      },
-      args: [`--force-device-scale-factor=${factor}`, `--window-size=${width},${height}`],
-    });
+  const browser = await puppeteer.launch({
+    headless: true,
+    defaultViewport: {
+      width,
+      height,
+    },
+    args: [`--force-device-scale-factor=${factor}`, `--window-size=${width},${height}`],
+  });
 
-    const page = await browser.newPage();
+  const context = browser.defaultBrowserContext();
+  context.clearPermissionOverrides();
+  context.overridePermissions("https://twitter.com", ["clipboard-read", "clipboard-write"]);
 
-    await page.goto(pageURL, {
-      waitUntil: "networkidle2",
-    });
+  const page = await browser.newPage();
 
-    await waitFor(4000);
+  await page.goto(pageURL, {
+    waitUntil: "networkidle2",
+    timeout: 5 * 60 * 1000,
+  });
 
-    // page.on("popup", (e) => console.log(e));
+  await waitFor(4000);
 
-    // await page.waitForNavigation({ waitUntil: "domcontentloaded" });
+  // page.on("popup", (e) => console.log(e));
 
-    const session = await page.target().createCDPSession();
-    await session.send("Emulation.setPageScaleFactor", {
-      pageScaleFactor: 0.5, // 400%
-    });
+  // await page.waitForNavigation({ waitUntil: "domcontentloaded" });
 
-    const tweets = await page.evaluate(() => {
-      const tweetNodes = Array.from(document.querySelectorAll('div[lang]:not([lang=""])'));
-      const data = tweetNodes.map((node) => ({
-        tweet: node.innerText,
-      }));
-      return data;
-    });
+  const session = await page.target().createCDPSession();
+  await session.send("Emulation.setPageScaleFactor", {
+    pageScaleFactor: 0.5, // 400%
+  });
 
-    // console.log(tweets);
+  // await page.exposeFunction("clipboardyRead", clipboardy.read);
 
-    return { data: tweets };
-  } catch (e) {
-    console.error(e);
-  }
+  const tweetIDs = await page.evaluate(async () => {
+    const ids = [];
+
+    /**
+     * Wait for `ms` amount of milliseconds
+     * @param {number} ms
+     */
+    const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    // Find the first Show thread button and click it
+    const showRepliesButton = [...document.querySelectorAll('div[dir="auto"]')]
+      .filter((node) => node.children[0] && node.children[0].tagName === "SPAN")
+      .find((node) => node.children[0].innerHTML === "Show replies");
+
+    if (showRepliesButton) {
+      showRepliesButton.click();
+
+      await waitFor(2000);
+    }
+
+    const timeNodes = Array.from(document.querySelectorAll("time"));
+
+    for (let timeNode of timeNodes) {
+      /** @type {HTMLAnchorElement | HTMLSpanElement} */
+      const timeContainerAnchor = timeNode.parentElement;
+
+      if (timeContainerAnchor.tagName === "SPAN") continue;
+
+      const id = timeContainerAnchor.href.split("/").reverse()[0];
+
+      ids.push(id);
+    }
+
+    return ids;
+  });
+
+  await browser.close();
+
+  return [tweetID, ...tweetIDs];
 };
 
-module.exports = { getTweet };
+module.exports = { getTweetIDs };

--- a/twindle-cli/twitter/scraping/index.js
+++ b/twindle-cli/twitter/scraping/index.js
@@ -1,1 +1,90 @@
-// once puppeteer is ready we can bring it into this folder
+const puppeteer = require("puppeteer");
+const { waitFor } = require("../utils/helpers");
+
+/**
+ * Get tweets(even older than 7 days) using puppeteer
+ * @param {string} tweetID
+ */
+const getTweetIDs = async (tweetID) => {
+  const pageURL = `https://twitter.com/anyone/status/${tweetID}`;
+
+  // Modify this variable to control the size of viewport
+  const factor = 0.2;
+  const height = Math.floor(2000 / factor);
+  const width = Math.floor(1700 / factor);
+
+  const browser = await puppeteer.launch({
+    headless: true,
+    defaultViewport: {
+      width,
+      height,
+    },
+    args: [`--force-device-scale-factor=${factor}`, `--window-size=${width},${height}`],
+  });
+
+  const context = browser.defaultBrowserContext();
+  context.clearPermissionOverrides();
+  context.overridePermissions("https://twitter.com", ["clipboard-read", "clipboard-write"]);
+
+  const page = await browser.newPage();
+
+  await page.goto(pageURL, {
+    waitUntil: "networkidle2",
+    timeout: 5 * 60 * 1000,
+  });
+
+  await waitFor(4000);
+
+  // page.on("popup", (e) => console.log(e));
+
+  // await page.waitForNavigation({ waitUntil: "domcontentloaded" });
+
+  const session = await page.target().createCDPSession();
+  await session.send("Emulation.setPageScaleFactor", {
+    pageScaleFactor: 0.5, // 400%
+  });
+
+  // await page.exposeFunction("clipboardyRead", clipboardy.read);
+
+  const tweetIDs = await page.evaluate(async () => {
+    const ids = [];
+
+    /**
+     * Wait for `ms` amount of milliseconds
+     * @param {number} ms
+     */
+    const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    // Find the first Show thread button and click it
+    const showRepliesButton = [...document.querySelectorAll('div[dir="auto"]')]
+      .filter((node) => node.children[0] && node.children[0].tagName === "SPAN")
+      .find((node) => node.children[0].innerHTML === "Show replies");
+
+    if (showRepliesButton) {
+      showRepliesButton.click();
+
+      await waitFor(2000);
+    }
+
+    const timeNodes = Array.from(document.querySelectorAll("time"));
+
+    for (let timeNode of timeNodes) {
+      /** @type {HTMLAnchorElement | HTMLSpanElement} */
+      const timeContainerAnchor = timeNode.parentElement;
+
+      if (timeContainerAnchor.tagName === "SPAN") continue;
+
+      const id = timeContainerAnchor.href.split("/").reverse()[0];
+
+      ids.push(id);
+    }
+
+    return ids;
+  });
+
+  await browser.close();
+
+  return [tweetID, ...tweetIDs];
+};
+
+module.exports = { getTweetIDs };

--- a/twindle-cli/twitter/transformations/tweets-array-endpoint.js
+++ b/twindle-cli/twitter/transformations/tweets-array-endpoint.js
@@ -1,0 +1,73 @@
+const {
+    createCustomTweet,
+  } = require("./helpers");
+  
+  const { renderRichTweets, fixUserDescription } = require("./rich-rendering");
+  
+  // const { doTweetsSearch } = require("./tweets-search-request");
+  const { format } = require("../utils/date");
+  
+  /**
+   *
+   * @param {any} responseJSON
+   */
+  function processTweetsArray(responseJSON) {
+    responseJSON = responseJSON.data;
+    const tweets = (responseJSON.data || []).map((resData) => ({
+        ...resData,
+        includes: responseJSON.includes,
+      }));
+    const firstTweet = tweets.filter((tweet) => tweet.id === tweet.conversation_id)[0];
+    const userObject = responseJSON.includes.users.filter(
+        (user) => user.id === firstTweet.author_id
+      )[0];
+    
+    let tweet = renderRichTweets(firstTweet);
+    let user = userObject;
+    
+    let resp = {
+      data: [],
+      common: {},
+    };
+  
+    resp.common.created_at = format(new Date(tweet.created_at), "MMM d, yyyy");
+    resp.common.user = { ...user };
+  
+    resp = fixUserDescription(resp);
+  
+    resp.common.user.profile_image_url = resp.common.user.profile_image_url.replace(
+      "_normal.",
+      "."
+    );
+  
+    resp.data.push(createCustomTweet(tweet, user));
+  
+    let directReplies = tweets
+        .filter((tweet) => tweet.referenced_tweets).filter(
+        (tweet) =>
+          tweet.referenced_tweets.filter(
+            (ref) => ref.type == "replied_to" && ref.id == tweet.conversation_id
+          ).length > 0
+      );
+    
+      while (directReplies.length > 0) {
+        let reply_id = directReplies[0].id;
+    
+        resp.data.push(createCustomTweet(renderRichTweets(directReplies[0])));
+        directReplies = tweets
+            .filter((tweet) => tweet.referenced_tweets).filter(
+          (tweet) =>
+            tweet.referenced_tweets.filter(
+              (ref) => ref.type == "replied_to" && ref.id == reply_id
+            ).length > 0
+        );
+      }
+  
+    resp.common.count = resp.data.length;
+    return resp;
+  }
+  
+  module.exports = {
+    processTweetsArray,
+  };
+  

--- a/twindle-cli/twitter/twitter.js
+++ b/twindle-cli/twitter/twitter.js
@@ -4,6 +4,7 @@ const { getConversationById, getTweetById } = require("./api");
 const TweetEndpointValidation = require("./validations/tweet-endpoint");
 
 const TweetEndpointTransformation = require("./transformations/tweet-endpoint");
+const TweetArrayEndpointTransformation = require("./transformations/tweets-array-endpoint");
 const SearchEndpointTransformation = require("./transformations/search-endpoint");
 
 const { ValidationErrors } = require("./error");
@@ -72,6 +73,17 @@ const getTweetsById = async (id, token) => {
   return finalTweetsData;
 };
 
+const getTweetsFromArray = async (ids, token) => {
+  let responseJSON = await getTweetById(ids.join(","), token);
+
+  if (responseJSON.status === "error") {
+    throw new Error("something wrong");
+  }
+
+  // do processing
+  return TweetArrayEndpointTransformation.processTweetsArray(responseJSON);
+};
+
 module.exports = {
-  getTweetsById,
+  getTweetsById, getTweetsFromArray
 };

--- a/twindle-cli/utils/helpers.js
+++ b/twindle-cli/utils/helpers.js
@@ -4,4 +4,13 @@
  */
 const waitFor = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-module.exports = { waitFor };
+/**
+ * Validate email
+ * @param {string} email
+ */
+function isValidEmail(email) {
+  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(String(email).toLowerCase());
+}
+
+module.exports = { waitFor, isValidEmail };

--- a/twindle-cli/utils/send-to-kindle.js
+++ b/twindle-cli/utils/send-to-kindle.js
@@ -1,20 +1,23 @@
 const fs = require("fs");
 const { sendMail } = require("./send-email");
 const { getFilenameFromPath } = require("../utils/path");
+const { blue, red } = require("kleur");
 
 async function sendToKindle(kindleEmail, filePath) {
-	const filename = getFilenameFromPath(filePath);
-	await sendMail({
-		emailTo: [kindleEmail],
-		subject: "From Twindle " + new Date().toLocaleDateString(),
-		attachments: [
-			{
-				filename,
-				path: filePath,
-			},
-		],
-	});
-	console.log(`Your file ${filename} has been sent to Kindle email address ${kindleEmail}`);
+  const filename = getFilenameFromPath(filePath);
+  await sendMail({
+    emailTo: [kindleEmail],
+    subject: "From Twindle " + new Date().toLocaleDateString(),
+    attachments: [
+      {
+        filename,
+        path: filePath,
+      },
+    ],
+  });
+  console.log(
+    `Your file ${red(filename)} has been sent to Kindle email address ${blue(kindleEmail)}`
+  );
 }
 
 module.exports = { sendToKindle };


### PR DESCRIPTION
## Modifications:
* Changes copied from main branch latest to the new branch:
  -  cli.js: send to email option code was modified
  - send-to-kindle.js: colors were used in the successful email console log line
  - helpers.js: validateEmail logic was copied over
  - puppeteer index was copied over to the older location as well as the scraping folder inside the twitter api
* Changes related to the Twitter API for puppeteer
  - twindle-cli/index.js was modified to call the new puppeteer code
  - twitter\twitter.js: a new function was added called to process an array of tweet ids returned by scraping project
  - twitter/transformations/tweets-array-endpoint.js: processes the multiple ids api hit response

## Things to do
* If tweet older than 7 days hook up puppeteer scraping project
* Test all flags/options in CLI application  and remove the -p flag finally

## Description


## Attach Screenshot


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
