### PR TITLE
Twitter 7daysold switchscraping

### DIFF
--- a/twindle-cli/twitter/twitter.js
+++ b/twindle-cli/twitter/twitter.js
@@ -1,4 +1,5 @@
 const { getConversationById, getTweetById } = require("./api");
+const { getTweetIDs } = require("./scraping")
 
 // const { firstTweet, finalProcessedTweet } = require("./test/data");
 const TweetEndpointValidation = require("./validations/tweet-endpoint");
@@ -47,7 +48,12 @@ const getTweetsById = async (id, token) => {
     if (validation.error instanceof ValidationErrors.TweetNotFirstOfThreadError) {
       const id = getConversationId(firstTweet.data);
       firstTweet = await getTweetById(id, token);
-    } else throw validation.error;
+    } else if (validation.error instanceof ValidationErrors.TweetOlderThan7DaysError) {
+      const tweetIDs = await getTweetIDs(id);
+      tweets = await getTweetsFromArray(tweetIDs, token);
+      return tweets;
+    }
+    else throw validation.error;
   }
 
   // do processing

--- a/twindle-cli/twitter/twitter.js
+++ b/twindle-cli/twitter/twitter.js
@@ -78,6 +78,7 @@ const getTweetsById = async (id, token) => {
     ...finalTweetsData,
     data: [...finalTweetsData.data, ...transformedSecondTweets],
   };
+  finalTweetsData.common.count = finalTweetsData.data.length;
 
   return finalTweetsData;
 };


### PR DESCRIPTION
## Description
* Switch to scraping logic if Tweet is older than 7 days
* The number of tweets on a thread in the common information on the pdf was incorrectly displayed as 1 - this was fixed

## Attach Screenshot


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
