### PR TITLE
improved file name 

### DIFF
--- a/twindle-cli/cli.js
+++ b/twindle-cli/cli.js
@@ -47,6 +47,12 @@ const getCommandlineArgs = (processArgv) =>
         describe: "Should use Puppeteer or not",
         type: "boolean",
       },
+      a: {
+        alias: "appendToFilename",
+        demandOption: false,
+        describe: "Append string to the filename",
+        type: "string"
+      }
     }).argv;
 
 // Intends to do such things for one time for the user, like config creating, main outputdir creation

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -41,7 +41,7 @@ async function main() {
     }-${
       (tweets && tweets.common && tweets.common.created_at.replace(/,/g, "").replace(/ /g, "-")) ||
       "thread"
-    }-${appendToFilename}`;
+    }${ appendToFilename ? "-" +appendToFilename : ""}`;
 
     const outputFilePath = getOutputFilePath(outputFilename || intelligentOutputFileName, format);
     await Renderer.render(tweets, format, outputFilePath);

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -36,7 +36,7 @@ async function main() {
     }
 
     const intelligentOutputFileName = `${
-      (tweets && tweets.common && tweets.common.user && tweets.common.user.username) || "twindle"
+      (tweets && tweets.common && tweets.common.user && tweets.common.user.username).replace("@", "") || "twindle"
     }-${
       (tweets && tweets.common && tweets.common.created_at.replace(/,/g, "").replace(/ /g, "-")) ||
       "thread"

--- a/twindle-cli/index.js
+++ b/twindle-cli/index.js
@@ -22,6 +22,7 @@ async function main() {
     kindleEmail,
     mock,
     shouldUsePuppeteer,
+    appendToFilename
   } = getCommandlineArgs(process.argv);
 
   try {
@@ -40,7 +41,7 @@ async function main() {
     }-${
       (tweets && tweets.common && tweets.common.created_at.replace(/,/g, "").replace(/ /g, "-")) ||
       "thread"
-    }`;
+    }-${appendToFilename}`;
 
     const outputFilePath = getOutputFilePath(outputFilename || intelligentOutputFileName, format);
     await Renderer.render(tweets, format, outputFilePath);


### PR DESCRIPTION
## Description
users can now specify the string to append at the end of the filename with the option `-a`
`node . -i 1325822584269795331 -a core-principles`

closes #733 

## Attach Screenshot
![Screenshot (115)](https://user-images.githubusercontent.com/28552728/98793552-12f3df80-242e-11eb-8068-be94e8a67664.png)


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
