### PR TITLE
Fetching user timeline tweets

### DIFF
--- a/twindle-cli/cli.js
+++ b/twindle-cli/cli.js
@@ -4,7 +4,7 @@ const { createLibraryIfNotExists } = require("./utils/library");
 const getCommandlineArgs = (processArgv) =>
   yargs(processArgv)
     .usage(
-      "Usage: -i <tweet id> -f <file format> -o <filename> -s <send to kindle email| Optionally pass kindle email here>"
+      "Usage: -i <tweet id> -u <user_id> -n <default_num_tweets> -f <file format> -o <filename> -s <send to kindle email| Optionally pass kindle email here>"
     )
     .option({
       i: {
@@ -52,7 +52,20 @@ const getCommandlineArgs = (processArgv) =>
         demandOption: false,
         describe: "Append string to the filename",
         type: "string"
-      }
+      },
+      u: {
+        alias: "userId",
+        demandOption: false,
+        describe: "The Twitter ID of the user whose timeline of recent tweets you are trying to read",
+        type: "string",
+      },
+      n: {
+        alias: "numTweets",
+        demandOption: false,
+        describe: "Used together with u option to specify the number of tweets to be read",
+        type: "integer",
+        default: 10
+      },
     }).argv;
 
 // Intends to do such things for one time for the user, like config creating, main outputdir creation

--- a/twindle-cli/twitter/api/twitter-endpoints/user_timeline.js
+++ b/twindle-cli/twitter/api/twitter-endpoints/user_timeline.js
@@ -1,0 +1,32 @@
+const { fetch } = require("../helpers/fetch");
+const { getCommonFields, MAX_RESULTS } = require("../constants");
+const { ApiErrors } = require("../../error");
+
+const BASE_ENDPOINT =
+  "https://api.twitter.com/2/tweets/search/recent?query=from:<screen_name>+-is:retweet+-has:mentions";
+
+/**
+ * @param {string} screen_name
+ */
+const getUrl = (screen_name) => {
+  let url = BASE_ENDPOINT;
+  url = url.replace("<screen_name>", screen_name);
+
+  const COMMON_FIELDS = getCommonFields();
+  return `${url}${COMMON_FIELDS}${MAX_RESULTS}`;
+};
+
+/**
+ * @param {string} id
+ * @param {string} screenName
+ * @param {string} token
+ */
+const getUserTweets = (screenName, token) => {
+  
+  const url = getUrl(screenName);
+  return fetch(url, token);
+};
+
+module.exports = {
+    getUserTweets,
+};

--- a/twindle-cli/twitter/transformations/rich-rendering.js
+++ b/twindle-cli/twitter/transformations/rich-rendering.js
@@ -43,22 +43,22 @@ function renderMedia(tweetObj) {
     // Let's get the entitites
     const urls = tweetObj.entities.urls;
 
-    const urlObjOfImageIndex = urls.findIndex(
+    const urlObjOfImageIndex = urls.filter(url=>url.expanded_url != undefined).findIndex(
       ({ expanded_url }) => expanded_url.includes("/photo/") || expanded_url.includes("/video/")
     );
 
     const urlObjOfImage = urls[urlObjOfImageIndex];
-
+    
     // Add to our list
     mediaObj[mediaInfo.type].push({
       width,
       height,
       preview_img_url: preview_image_url || url,
-      link: urlObjOfImage.expanded_url,
+      link: urlObjOfImage === undefined ? "" : urlObjOfImage.expanded_url
     });
 
     // Get the actual short URL (t.co/[STUFF])
-    const shortURL = urlObjOfImage.url;
+    const shortURL = urlObjOfImage === undefined ? "" : urlObjOfImage.url;
 
     // Replace in the tweet text
     tweetText = tweetText.replace(shortURL, "");

--- a/twindle-cli/twitter/transformations/user-timeline-endpoint.js
+++ b/twindle-cli/twitter/transformations/user-timeline-endpoint.js
@@ -1,0 +1,52 @@
+const { createCustomTweet } = require("./helpers");
+
+const { renderRichTweets, fixUserDescription } = require("./rich-rendering");
+
+const { formatTimestamp } = require("../utils/date");
+
+/**
+ * @param {TwitterConversationResponse} responseJSON
+ */
+async function processUserTweets(screenName, responseJSON, token) {
+  const tweets = (responseJSON.data || []).map((resData) => ({
+    ...resData,
+    includes: responseJSON.includes,
+  }));
+
+  const userObject = responseJSON.includes.users
+                    .filter((user)=>user.username === screenName)[0];
+
+  let user = userObject;
+
+  /** @type {CustomTweetsObject} */
+  let resp = {
+    data: [],
+    common: {},
+  };
+
+  resp.common.created_at = formatTimestamp(user.created_at);
+  resp.common.user = { ...user };
+
+  resp = fixUserDescription(resp);
+
+  resp.common.user.profile_image_url = resp.common.user.profile_image_url.replace("_normal.", ".");
+
+
+
+  let conversations = [];
+  for (let tweet of tweets) {
+    if(!conversations.includes(tweet.conversation_id))  {
+      conversations.push(tweet.conversation_id);
+      let threadTweets = tweets.filter((t)=>tweet.conversation_id === t.conversation_id);
+      for(i = threadTweets.length-1; i >= 0; i--) {
+        resp.data.push(createCustomTweet(await renderRichTweets(threadTweets[i], token)));
+      }
+    }
+  }
+  resp.common.count = resp.data.length;
+  return resp;
+}
+
+module.exports = {
+  processUserTweets,
+};

--- a/twindle-cli/twitter/twitter.js
+++ b/twindle-cli/twitter/twitter.js
@@ -9,8 +9,10 @@ const TweetEndpointValidation = require("./validations/tweet-endpoint");
 const TweetEndpointTransformation = require("./transformations/tweet-endpoint");
 const TweetArrayEndpointTransformation = require("./transformations/tweets-array-endpoint");
 const SearchEndpointTransformation = require("./transformations/search-endpoint");
+const UserTimelineEndpointTransformation = require("./transformations/user-timeline-endpoint");
 
 const { ValidationErrors } = require("./error");
+const { getUserTweets } = require("./api/twitter-endpoints/user_timeline");
 
 /** @param {TwitterConversationResponse} response */
 const getConversationId = (response) => response.data[0].conversation_id;
@@ -103,7 +105,19 @@ const getTweetsFromArray = async (ids, token) => {
   return await TweetArrayEndpointTransformation.processTweetsArray(responseJSON.data, token);
 };
 
+const getTweetsFromUser = async( screenName, token) => {
+  let responseJSON = await getUserTweets(screenName, token);
+  
+  if (responseJSON.status === "error") {
+    throw new Error("something wrong");
+  }  
+  // do processing
+  return await UserTimelineEndpointTransformation.processUserTweets(screenName, responseJSON.data, token);  
+
+}
+
 module.exports = {
   getTweetsById,
   getTweetsFromArray,
+  getTweetsFromUser
 };


### PR DESCRIPTION
* Introduced two new command line options u for userId and n for number of tweets(default value 10)
* If instead of the id, the u option is provided, then user's recent tweets are fetched
* Lots of testing needs to be done for how the tweets and their replies are displayed - I am ignoring retweets or replies to other users or tweets having any user mentions for now. These can be added down the road if necessary - any PDF structure change necessary needs to be accomplished by creating a separate template
* richRendering was causing some weird bugs - I have tried my best to fix them but puru needs to take a look at the changes to see if they are correct.
* Since the API endpoint used is a search endpoint only tweets made by the user in the last 7 days will be displayed. How to handle no tweets scenario??

## Description


## Attach Screenshot


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
