### PR TITLE
Github as a source now renders

### DIFF
--- a/twindle-cli/.gitignore
+++ b/twindle-cli/.gitignore
@@ -1,3 +1,4 @@
 TwindleLibrary
 nodemailer.config.json
 generated-mock
+jsonLibrary

--- a/twindle-cli/src/cli.js
+++ b/twindle-cli/src/cli.js
@@ -1,25 +1,21 @@
+const { format } = require("date-fns");
 const yargs = require("yargs");
+const { UserError } = require("./helpers/error");
 const { createLibraryIfNotExists } = require("./utils/library");
+const sendEmail = require("./utils/send-email");
+const { isValidEmail } = require("./utils/helpers");
+
 
 const getCommandlineArgs = (processArgv) =>
   yargs(processArgv)
     .usage(
-      "Usage: -i <tweet id or a comma separated list of tweet ids> -r <include replies by author of thread to other users> -u <user_id> -n <default_num_tweets> -f <file format> -o <filename> -s <send to kindle email| Optionally pass kindle email here>"
+      "Usage: -i <tweet id or a comma separated list of tweet ids> -r <include replies by author of thread to other users>" + 
+       " -u <user_id> -n <default_num_tweets>" + 
+       " -f <file format - pdf | epub>" + 
+       " -o <filename> -a<if o is not present a file name is calculated and this a text can be appended to it" + 
+       " -s <send to kindle email| Optionally pass kindle email here>"
     )
     .option({
-      i: {
-        alias: "tweetId",
-        demandOption: false,
-        describe: "First tweet's tweet id in of the twitter thread",
-        type: "string",
-      },
-      r: {
-        alias: "includeReplies",
-        demandOption: false,
-        describe: "include replies by thread author",
-        type: "boolean",
-        default: false
-      },
       f: {
         alias: "format",
         demandOption: false,
@@ -33,6 +29,25 @@ const getCommandlineArgs = (processArgv) =>
         demandOption: false,
         describe: "Filename for the output file",
         type: "string",
+      },
+      a: {
+        alias: "appendToFilename",
+        demandOption: false,
+        describe: "Append string to the filename",
+        type: "string",
+      },    
+      i: {
+        alias: "tweetId",
+        demandOption: false,
+        describe: "First tweet's tweet id in of the twitter thread",
+        type: "string",
+      },
+      r: {
+        alias: "includeReplies",
+        demandOption: false,
+        describe: "include replies by thread author",
+        type: "boolean",
+        default: false
       },
       s: {
         alias: "kindleEmail",
@@ -48,24 +63,25 @@ const getCommandlineArgs = (processArgv) =>
         describe: "If set, will run in mock mode",
         type: "boolean",
       },
+      ms: {
+        alias: "mockSource",
+        demandOption: false,
+        describe: "To be used with mock flag",
+        type: "string",
+        default: "twitter"
+      },
       "generate-mock": {
         alias: "generateMock",
         demandOption: false,
         describe: "generates a mock json file of the current data",
         type: "boolean",
-        default: false,
+        default: true,
       },
       p: {
         alias: "shouldUsePuppeteer",
         demandOption: false,
         describe: "Should use Puppeteer or not",
         type: "boolean",
-      },
-      a: {
-        alias: "appendToFilename",
-        demandOption: false,
-        describe: "Append string to the filename",
-        type: "string",
       },
       u: {
         alias: "userId",
@@ -86,6 +102,19 @@ const getCommandlineArgs = (processArgv) =>
         demandOption: false,
         describe: "The README.md file of git Repo",
         type: "string"
+      },
+      h: {
+        alias: "storyKeyword",
+        demandOption: false,
+        describe: "Keyword to search for hackernews stories",
+        type: "string"
+      },
+      nh: {
+        alias: "numStories",
+        demandOption: false,
+        describe: "Used together with h option to specify the number of stories to be read",
+        type: "integer",
+        default: 10,
       }
     }).argv;
 
@@ -95,7 +124,160 @@ function prepareCli() {
   createLibraryIfNotExists();
 }
 
+function getCommandLineObject() {
+  const {
+    format,
+    outputFilename,
+    tweetId,
+    includeReplies,
+    kindleEmail,
+    mock,
+    mockSource,
+    shouldUsePuppeteer,
+    appendToFilename,
+    userId,
+    numTweets,
+    generateMock,
+    gitHubURL,
+    storyKeyword,
+    numStories
+  } = getCommandlineArgs(process.argv);
+  
+  const cliObject = {};
+  appendFileFormat(cliObject, format);
+  appendOutputFileName(cliObject, outputFilename, appendToFilename);
+  appendKindleEmail(cliObject, kindleEmail);
+  appendTwitterSource(cliObject, tweetId, includeReplies, userId, numTweets);
+  appendGithubSource(cliObject, gitHubURL);
+  appendHackernewsSource(cliObject, storyKeyword, numStories);
+  appendMock(cliObject, mock, mockSource);
+  validateCliObject(cliObject);
+  cliObject.generateMock = process.argv.includes("-generate-mock") && generateMock;
+  return cliObject;
+}
+
+const appendFileFormat = (cliObject, format) => {
+  if(format != "pdf" && format != "epub")
+    throw new UserError("file-format-not-supported", 
+      "Currently only pdf and epub formats are supported. Please choose one of the two");
+  cliObject.format = format;
+  return cliObject;
+}
+
+const appendOutputFileName = (cliObject, outputFilename, appendToFilename) => {
+  if(outputFilename || appendToFilename) {
+    cliObject.fileName = {};
+    if(outputFilename)
+      cliObject.fileName.outputFilename = outputFilename;
+    else
+      cliObject.fileName.appendToFilename = appendToFilename;
+  }
+  return cliObject;
+}
+
+const appendKindleEmail = (cliObject, kindleEmail) => {
+  if (process.argv.includes("-s")) {
+    if (!process.env.HOST || !process.env.EMAIL || !process.env.PASS)
+      throw new UserError(
+        "mail-server-config-error",
+        "Please setup the credentials for the mail server to send the email to Kindle"
+      );
+    if (!kindleEmail) {
+      throw new UserError(
+        "empty-kindle-email",
+        "Pass your kindle email address with -s or configure it in the .env file"
+      );
+    }
+
+    if (!isValidEmail(kindleEmail)) {
+      const errorMessage = !!process.argv[process.argv.indexOf("-s") + 1]
+        ? "Enter a valid email address"
+        : "Kindle Email configured in .env file is invalid";
+      throw new UserError("invalid-email", errorMessage);
+    }
+    cliObject.kindleEmail = kindleEmail;
+  }
+  return cliObject;
+}
+
+const appendTwitterSource = (cliObject, tweetId, includeReplies, userId, numTweets) => {
+  if(process.argv.includes("-i") && process.argv.includes("-u"))
+    throw new UserError("invalid-combination-of-twitter-params", 
+      "Please choose either tweet ids or user ids");
+  if (!process.env.TWITTER_AUTH_TOKEN)
+    throw new UserError(
+      "bearer-token-not-provided",
+      "Please ensure that you have a .env file containing a value for TWITTER_AUTH_TOKEN"
+    );
+  if(process.argv.includes("-i") || process.argv.includes("-u")) {
+    cliObject.dataSource = "twitter";
+    cliObject.twitter = {};
+    if(tweetId) {
+      if(process.argv.includes("-n"))
+        throw new UserError("invalid-combination-of-twitter-params", 
+          "Cannot include -n for the tweet id option");
+      cliObject.twitter.tweetId = tweetId;
+      cliObject.twitter.includeReplies = process.argv.includes("-r") && includeReplies;
+    } else {
+      if(process.argv.includes("-r"))
+        throw new UserError("invalid-combination-of-twitter-params", 
+          "Cannot include -r for the user id option");
+      cliObject.twitter.userId = userId;
+      cliObject.twitter.numTweets = numTweets;
+    }
+  }
+  return cliObject;
+}
+
+const appendGithubSource = (cliObject, gitHubURL) => {
+  if(cliObject.dataSource && process.argv.includes("-g")) {
+    throw new UserError("invalid-combination-of-input-arguments", 
+        "Cannot include -g together with twitter related params");
+  }
+  if(process.argv.includes("-g")) {
+    cliObject.dataSource = "github";
+    cliObject.github = {};
+    cliObject.github.githubURL = gitHubURL;
+  }
+  return cliObject;
+}
+
+const appendHackernewsSource = (cliObject, storyKeyword, numStories) => {
+  if(cliObject.dataSource && process.argv.includes("-h")) {
+    throw new UserError("invalid-combination-of-input-arguments", 
+        "Cannot include -h together with twitter or github related params");
+  }
+  if(process.argv.includes("-h")) {
+    cliObject.dataSource = "hackernews";
+    cliObject.hackernews = {};
+    cliObject.hackernews.storyKeyword = storyKeyword;
+    cliObject.hackernews.numStories = numStories;
+  }
+  return cliObject;
+}
+
+const appendMock = (cliObject, mock, mockSource) => {
+  if(cliObject.dataSource && process.argv.includes("-m")) {
+    throw new UserError("invalid-combination-of-input-arguments", 
+        "Cannot include -m together with twitter or github or hackernews related params");
+  }
+  if(cliObject.mock && !process.argv.includes("-ms")) {
+    throw new UserError("invalid-combination-of-input-arguments", 
+        "Cannot use -m option without -ms which is the source for the mock option");
+  }
+  if(process.argv.includes("-m")) {
+    cliObject.mockSource = mockSource;
+  }
+}
+
+const validateCliObject = (cliObject) => {
+  if(!cliObject.dataSource && !cliObject.mock) 
+    throw new UserError("invalid-combination-of-input-arguments", 
+      "Either one of the sources information must be specified or the mock flag must be set, otherwise the application will not run");
+}
+
 module.exports = {
   getCommandlineArgs,
   prepareCli,
+  getCommandLineObject
 };

--- a/twindle-cli/src/github/githubparse/app.js
+++ b/twindle-cli/src/github/githubparse/app.js
@@ -1,21 +1,33 @@
 const {convertHTML} = require('./convert')
 const {jsonfetchData} = require('./jsonFetchData')
 const fs = require('fs')
-const path = require('path')
+const path = require('path');
+const { UserError } = require('../../helpers/error');
 
 
-async function main(urlData){
-    const url =  new URL(urlData)
+async function getHtml(urlData){
+    const url =  new URL(urlData);
+    const urlExtension = path.extname(url.pathname);
+    if(urlExtension !== ".md"){
+        throw new UserError("invalid-file-format-github", "Can currently only read MD files");
+    }
     const readmeFileName = path.basename(url.pathname,'.md')
     const gituser = url.pathname.split('/')[1]
     const repoName = url.pathname.split('/')[2]
+    const branch = url.pathname.split('/')[4];
     const repoURL = `https://api.github.com/repos/${gituser}/${repoName}`
-    const data = {
+    const data = [];
+    const repoResponse = {
         common : await jsonfetchData(repoURL),
-        html : await convertHTML(urlData)
-    }
-    fs.writeFileSync(`./jsonLibrary/${repoName}_${readmeFileName}.json`, JSON.stringify(data,null,2) )
-    
+        htmlValue : await convertHTML(urlData)
+    };
+    repoResponse.common.branch = branch;
+
+    data.push(repoResponse);
+    fs.writeFileSync(`${__dirname}/jsonLibrary/${repoName}_${readmeFileName}.json`, JSON.stringify(data,null,2) )
+    return data;    
 }
 
-main("https://github.com/ryanmcdermott/clean-code-javascript/blob/master/README.md")
+//main("https://github.com/ryanmcdermott/clean-code-javascript/blob/master/README.md")
+
+module.exports = {getHtml};

--- a/twindle-cli/src/github/githubparse/convert.js
+++ b/twindle-cli/src/github/githubparse/convert.js
@@ -13,11 +13,13 @@ if(extension !== ".md"){
 }
 const gituser = url.pathname.split('/')[1]
 const repoName = url.pathname.split('/')[2]
+const branch = url.pathname.split('/')[4];
 const rawFile = fetchURL.replace("github.com", "raw.githubusercontent.com").replace("/blob/", "/")
-
+const replaceURL = `https://raw.githubusercontent.com/${gituser}/${repoName}/${branch}/`;
 return fetch(rawFile)
     .then(response => response.text())
     .then((body)=>{
+        body = body.replace(/\.\//g, replaceURL);
         const dataJSON = converter.makeHtml(body)
         
        return dataJSON

--- a/twindle-cli/src/github/githubparse/jsonFetchData.js
+++ b/twindle-cli/src/github/githubparse/jsonFetchData.js
@@ -1,4 +1,5 @@
-const fetch = require('node-fetch')
+const fetch = require('node-fetch');
+const {formatTimestamp} = require('../../utils/date');
 
 const jsonfetchData= (url) => fetch(url)
 .then(res => res.json())
@@ -6,11 +7,12 @@ const jsonfetchData= (url) => fetch(url)
     const datajson = {
         
             repoName : jsonData.name,
-            creationDate : jsonData.created_at,
-            loginName : jsonData.owner.login,
-            ownerImage :jsonData.owner.avatar_url
-       
-    }
+            created_at : formatTimestamp(jsonData.created_at),
+            user : {
+                username: jsonData.owner.login,
+                profile_image_url: jsonData.owner.avatar_url
+            }       
+    };
 
     return datajson
 

--- a/twindle-cli/src/index.js
+++ b/twindle-cli/src/index.js
@@ -1,6 +1,6 @@
 require("./helpers/logger");
 require("dotenv").config();
-const { getCommandlineArgs, prepareCli } = require("./cli");
+const { getCommandLineObject, prepareCli } = require("./cli");
 const Renderer = require("./renderer");
 const { getTweetsFromArray, getTweetsFromUser, getTweetsFromThreads } = require("./twitter");
 const { getOutputFilePath } = require("./utils/path");
@@ -9,88 +9,39 @@ const { getTweetIDs } = require("./twitter/scraping");
 const { UserError } = require("./helpers/error");
 const { red, cyan ,bgRed } = require("kleur");
 const { formatLogColors } = require("./utils/helpers");
-const { isValidEmail } = require("./utils/helpers");
+
 const spinner = require("./spinner");
 const { writeFile, mkdir } = require("fs").promises;
 const converthtml = require('./github/convert')
-const path = require('path')
+const path = require('path');
+const { getHtml } = require("./github/githubparse/app");
+const cli = require("./cli");
 
 async function main() {
-  prepareCli();
-
-  spinner.start();
-
-  const {
-    format,
-    outputFilename,
-    tweetId,
-    includeReplies,
-    kindleEmail,
-    mock,
-    shouldUsePuppeteer,
-    appendToFilename,
-    userId,
-    numTweets,
-    generateMock,
-    gitHubURL
-  } = getCommandlineArgs(process.argv);
-  let dataSrc = "";
-  if(gitHubURL){
-    dataSrc = "github";
-    const giturl = new URL(gitHubURL)
-    const urlExtension = path.extname(giturl.pathname)
-    if(urlExtension !== ".md"){
-    return spinner.fail(bgRed("Please enter another URL having markdown extension(.md)"));
-    }
-    
-    return spinner.succeed(`Your ${cyan('files')} are saved into ${formatLogColors[format](converthtml(gitHubURL))}`)
-  }
-
   try {
-    verifyEnvironmentVariables(kindleEmail);
+    prepareCli();
+    spinner.start();
+    let cliObject = getCommandLineObject();
+    //console.log(cliObject);
+    const data = await getDataFromSource(cliObject);
+    let outputFilename = cliObject.fileName && cliObject.fileName.outputFilename ? 
+                          cliObject.fileName.outputFilename : "";
+    if(!outputFilename)
+      outputFilename = calculateFileName(cliObject, data);
+    await writeToMockFile(cliObject, outputFilename, data);
 
-    const tweets = await getTweets({ tweetId, includeReplies, mock, shouldUsePuppeteer, userId, numTweets });
-    if(tweets.length > 0)
-      dataSrc = "twitter";
-    const intelligentOutputFileName = `${
-      (
-        tweets[0] &&
-        tweets[0].common &&
-        tweets[0].common.user &&
-        tweets[0].common.user.username
-      ).replace("@", "") || "twindle"
-    }-${
-      (tweets[0] &&  
-        tweets[0].common &&
-        tweets[0].common.created_at.replace(/,/g, "").replace(/ /g, "-")) ||
-      "thread"
-    }${appendToFilename ? "-" + appendToFilename : ""}`;
+    const outputFilePath = getOutputFilePath(outputFilename, cliObject.format);
+    await Renderer.render(data, cliObject.dataSource, cliObject.format, outputFilePath);
 
-    if (generateMock) {
-      try {
-        await mkdir("./generated-mock");
-      } catch {}
-
-      // Create mock file with the appropriate name
-      await writeFile(
-        `./generated-mock/@CUSTOM-OUTPUT_${intelligentOutputFileName}.json`,
-        JSON.stringify(tweets, null, 2)
-      );
-
-    }
-
-    const outputFilePath = getOutputFilePath(outputFilename || intelligentOutputFileName, format);
-    await Renderer.render(tweets, dataSrc, format, outputFilePath);
-
-    if (process.argv.includes("-s")) {
-      console.devLog("sending to kindle", kindleEmail);
-      await sendToKindle(kindleEmail, outputFilePath);
+    if (cliObject.kindleEmail) {
+      console.devLog("sending to kindle", cliObject.kindleEmail);
+      await sendToKindle(cliObject.kindleEmail, outputFilePath);
     }
 
     const [fileName] = outputFilePath.split("/").reverse();
 
     spinner.succeed(
-      "Your " + cyan("tweets") + " are saved into " + formatLogColors[format](fileName)
+      "Your " + cyan("data") + " saved into " + formatLogColors[cliObject.format](fileName)
     );
     //console.log("Your " + cyan("tweets") + " are saved into " + formatLogColors[format](fileName));
   } catch (e) {
@@ -105,6 +56,20 @@ async function main() {
   process.exit();
 }
 
+async function getDataFromSource(cliObject) {
+  if(cliObject.dataSource) {
+    if(cliObject.dataSource === "github")
+      return getDataFromGithub(cliObject.github);
+    else if(cliObject.dataSource === "twitter")
+      return getTweets(cliObject.twitter);
+    else if(cliObject.dataSource === "hackernews")
+      return getDataFromHackernews(cliObject.hackernews);
+  }
+  if(cliObject.mock) {
+    return getDataFromMock(cliObject.mock);
+  }  
+}
+
 /**
  *
  * @param {Object} param
@@ -114,19 +79,14 @@ async function main() {
  * @param {string} param.userId
  * @param {number} param.numTweets
  */
-async function getTweets({ tweetId, includeReplies, mock, shouldUsePuppeteer, userId, numTweets }) {
+async function getTweets(cliObject) {
   /** @type {CustomTweetsObject[]} */
   let tweets;
 
-  if (mock) {
-    tweets = require("./twitter/mock/twitter-mock-responses/only-links.json");
-    return tweets;
-  }
+  if (cliObject.userId) {
+    tweets = await getTweetsFromUser(cliObject.userId, process.env.TWITTER_AUTH_TOKEN);
 
-  if (userId) {
-    tweets = await getTweetsFromUser(userId, process.env.TWITTER_AUTH_TOKEN);
-
-    if (tweets[0].data.length > numTweets) {
+    if (tweets[0].data.length > cliObject.numTweets) {
       tweets[0].data = tweets[0].data.slice(0, numTweets);
       tweets[0].common.count = tweets[0].data.length;
     }
@@ -134,48 +94,45 @@ async function getTweets({ tweetId, includeReplies, mock, shouldUsePuppeteer, us
     return tweets;
   }
 
-  if (shouldUsePuppeteer) {
-    const tweetIDs = await getTweetIDs(tweetId);
-    tweets = await getTweetsFromArray(tweetIDs, includeReplies, process.env.TWITTER_AUTH_TOKEN);
-
-    return tweets;
-  }
-
-  tweets = await getTweetsFromThreads(tweetId, includeReplies, process.env.TWITTER_AUTH_TOKEN);
-
+  tweets = await getTweetsFromThreads(cliObject.tweetId, cliObject.includeReplies, process.env.TWITTER_AUTH_TOKEN);
   return tweets;
 }
 
-function verifyEnvironmentVariables(kindleEmail) {
-  if (!process.env.TWITTER_AUTH_TOKEN)
-    throw new UserError(
-      "bearer-token-not-provided",
-      "Please ensure that you have a .env file containing a value for TWITTER_AUTH_TOKEN"
-    );
 
-  if (process.argv.includes("-s")) {
-    if (!process.env.HOST || !process.env.EMAIL || !process.env.PASS)
-      throw new UserError(
-        "mail-server-config-error",
-        "Please setup the credentials for the mail server to send the email to Kindle"
-      );
-    if (!kindleEmail) {
-      spinner.fail("UserError");
-      throw new UserError(
-        "empty-kindle-email",
-        "Pass your kindle email address with -s or configure it in the .env file"
-      );
-    }
-
-    if (!isValidEmail(kindleEmail)) {
-      const errorMessage = !!process.argv[process.argv.indexOf("-s") + 1]
-        ? "Enter a valid email address"
-        : "Kindle Email configured in .env file is invalid";
-      spinner.fail("UserError");
-      throw new UserError("invalid-email", errorMessage);
-    }
-  }
+async function getDataFromGithub({githubURL}) {
+  return await getHtml(githubURL);
 }
 
+function calculateFileName(cliObject, data) {
+  const intelligentOutputFileName = `${
+    (
+      data[0] &&
+      data[0].common &&
+      data[0].common.user &&
+      data[0].common.user.username
+    ).replace("@", "") || "twindle"
+  }-${
+    (data[0] &&  
+      data[0].common &&
+      data[0].common.created_at.replace(/,/g, "").replace(/ /g, "-")) ||
+    "thread"
+  }${cliObject.appendToFilename ? "-" + cliObject.appendToFilename : ""}`;
+  return intelligentOutputFileName;
+}
+
+async function writeToMockFile(cliObject, outputFilename, data) {
+  if (cliObject.generateMock) {
+    try {
+      await mkdir("./generated-mock");
+    } catch {}
+
+    // Create mock file with the appropriate name
+    await writeFile(
+      `./generated-mock/@CUSTOM-OUTPUT_${outputFilename}.json`,
+      JSON.stringify(data, null, 2)
+    );
+
+  }
+}
 // Execute it
 main();

--- a/twindle-cli/src/renderer/pdf/index.js
+++ b/twindle-cli/src/renderer/pdf/index.js
@@ -11,9 +11,11 @@ async function generatePDF(srcData, src, outputPath) {
     parameter,
     src
   );
+  
 
   // creates the pdf from html and saves it to Twindle.pdf
-  if (srcData[0].data.length > 0) await createPdf(outputPath, htmlContent);
+  if (srcData.length > 0) await createPdf(outputPath, htmlContent);
+  
 
   return;
 }

--- a/twindle-cli/src/renderer/pdf/render-template.js
+++ b/twindle-cli/src/renderer/pdf/render-template.js
@@ -10,6 +10,8 @@ const { join } = require("path");
 async function renderTemplate(data, src) {
   if(src == "twitter")
     return await renderTwitterTemplate(data);
+  else if(src == "github")
+    return await renderGithubTemplate(data);
 }
 
 async function renderTwitterTemplate(data) {
@@ -24,6 +26,33 @@ async function renderTwitterTemplate(data) {
   hbs.registerPartial('user-info-partial', userInfohtml);
   hbs.registerPartial('tweet-partial', tweethtml);
   hbs.registerPartial('reply-partial', replyhtml);
+  hbs.registerPartial('style', css);
+  
+  // creates the Handlebars template object
+  const template = hbs.compile(threadsHtml, {
+    strict: true,
+  });
+  
+  // renders the html template with the given data
+  const rendered = template(data);
+
+  const tmpPath = join(tmpdir(), "hello.html");
+  await writeFile(tmpPath, rendered, "utf-8");
+  await writeFile(tmpdir() + "/x.json", JSON.stringify(data, null, 2), "utf-8");
+  console.devLog("rendered saved to ", tmpPath);
+  return rendered;
+}
+
+async function renderGithubTemplate(data) {
+  const threadsHtml = await readFile(`${__dirname}/../templates/github/threads-template.hbs`, "utf-8");
+  const reposHtml = await readFile(`${__dirname}/../templates/github/repos-partial.hbs`, "utf-8");
+  const userInfohtml = await readFile(`${__dirname}/../templates/github/user-info-partial.hbs`, "utf-8");
+  const repoHtml = await readFile(`${__dirname}/../templates/github/repo-partial.hbs`, "utf-8");
+  const css = await readFile(`${__dirname}/../templates/github/style.css`, "utf-8");
+
+  hbs.registerPartial('repos-partial', reposHtml);
+  hbs.registerPartial('user-info-partial', userInfohtml);
+  hbs.registerPartial('repo-partial', repoHtml);
   hbs.registerPartial('style', css);
   
   // creates the Handlebars template object

--- a/twindle-cli/src/renderer/templates/github/Toc.hbs
+++ b/twindle-cli/src/renderer/templates/github/Toc.hbs
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xml:lang="<%- lang %>"
+  lang="<%- lang %>">
+
+<head>
+  <title><%= title %></title>
+  <meta charset="UTF-8" />
+  <!--<link rel="stylesheet" type="text/css" href="Epub.css" />-->
+</head>
+
+<body>
+  <h1 id="tocHeader">Your Twindle Thread from</h1>
+  
+  {{#each this}}
+  {{#if common}}
+  <div class="tweetContainer" style="page-break-before: always;">
+    <div class="header">
+      {{#if common.user}}
+      <img src="{{common.user.profile_image_url}}" alt="{{common.user.username}}" />
+      {{/if}}
+      <div>
+        {{#if common.user}}
+        <h3>
+          {{common.user.username}}
+          {{/if}}
+          <span class="user-handle">
+            <a href="https://github.com/{{common.user.username}}/{{common.repoName}}">{{common.repoName}}</a>
+          </span>
+        </h3>
+        <p>
+          <span>
+            Repository created:
+            {{common.created_at}}
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+{{/if}}
+  {{/each}}
+  
+</body>
+
+</html>

--- a/twindle-cli/src/renderer/templates/github/repo-partial.hbs
+++ b/twindle-cli/src/renderer/templates/github/repo-partial.hbs
@@ -1,0 +1,3 @@
+{{> user-info-partial this }}
+<br/>
+{{{htmlValue}}}

--- a/twindle-cli/src/renderer/templates/github/repos-partial.hbs
+++ b/twindle-cli/src/renderer/templates/github/repos-partial.hbs
@@ -1,0 +1,3 @@
+{{#each this}}
+  {{>repo-partial this}}
+{{/each}}

--- a/twindle-cli/src/renderer/templates/github/style.css
+++ b/twindle-cli/src/renderer/templates/github/style.css
@@ -1,0 +1,241 @@
+* {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans",
+      "Helvetica Neue", sans-serif;
+
+  }
+  body {
+    margin: 10px 10px 20px 10px;
+    font-size: 108%;
+  }
+
+  a[href] {
+    text-decoration: none !important;
+  }
+
+  a[href]:not(.link-box-anchor):not(.embedded-tweet-anchor) {
+    color: rgb(29, 161, 242);
+    text-decoration: none;
+    background-image: linear-gradient(transparent 0%, transparent 35%, rgba(29, 161, 242, 0.3) 35%, rgba(29, 161, 242, 0.3) 100%);
+    background-size: 100% 200%;
+    background-position: 0px 0px;
+    word-break: break-word;
+  }
+
+  #title {
+    text-align: center;
+  }
+
+  ul {
+    list-style-type: none;
+
+    /*display: flex;*/
+    align-items: center;
+    justify-content: stretch;
+    /*flex-direction: column;*/
+    padding: 0;
+  }
+
+  ul li {
+    margin: 0;
+
+    width: 100%;
+
+    padding: 1rem 0;
+  }
+
+  ul li:not(:last-child) {
+    border-bottom: solid 1px rgba(0, 0, 0, 0.3);
+  }
+
+  .tweetContainer {
+    /*display: flex;
+  flex-direction: column;*/
+    width: 100%;
+  }
+
+  .tweetContainer * {
+    margin: 0;
+    padding: 0;
+  }
+
+  .tweetContainer a.media-link {
+    width: 100%;
+  }
+
+  .tweetContainer .tweet-img {
+    margin: 10px 0;
+
+    border-radius: 0.5rem;
+
+    max-width: 100%;
+    height: auto;
+  }
+
+  .tweetContainer .header {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .tweetContainer .header img {
+    max-width: 75px;
+    border-radius: 50%;
+    margin-right: 10px;
+  }
+
+  .tweetContainer .header>div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+  }
+
+  .tweetContainer .header>div p {
+    font-size: 14px;
+  }
+
+  .tweetContainer .header>div span {
+    font-style: italic;
+    color: rgb(45, 45, 45);
+  }
+
+  img.emoji,
+  .verified-badge {
+    height: 1em;
+    width: 1em;
+    margin: 0 .05em 0 .1em;
+    vertical-align: -0.1em;
+  }
+
+  .user-handle {
+    color: rgba(0, 0, 0, 0.5) !important;
+  }
+
+  .link-box-anchor {
+    width: 100%;
+  }
+
+  .link-box {
+    width: 100%;
+    height: 135px;
+
+    margin: 10px 0;
+
+    border-radius: 0.5rem;
+
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
+
+    background-color: rgba(0, 0, 0, 0.06);
+
+    /*display: flex;*/
+  }
+
+  .link-box .link-img-container {
+    height: 100%;
+
+    border-radius: 0.5rem 0 0 0.5rem;
+  }
+
+  .link-box .link-img-container img {
+    border-radius: inherit;
+
+    height: 100%;
+    width: auto;
+  }
+
+  .link-box>.link-box-content {
+
+    /*flex: 1;*/
+
+    color: initial;
+
+    position: relative;
+
+    padding: 5px 0;
+    padding-left: .5rem;
+
+    /*display: flex;
+    flex-direction: column;*/
+    justify-content: space-between;
+  }
+
+  .link-box-content-heading,
+  .link-box-content-description,
+  .link-box-content-domain {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+
+    font-size: 0.95rem;
+  }
+
+  .link-box-content-description,
+  .link-box-content-domain {
+    color: rgba(0, 0, 0, 0.7);
+    font-size: 0.85rem;
+  }
+
+  .link-box-content-domain {
+    /*display: flex;*/
+    align-items: center;
+  }
+
+  .link-box-content-domain .link-svg {
+    width: 0.9rem;
+    fill: rgba(0, 0, 0, 0.7);
+
+    margin-right: 0.5rem;
+  }
+
+  .embedded-tweet-anchor {
+    color: rgba(0, 0, 0, 0.9) !important;
+    font-size: 1rem;
+
+  }
+
+  .embedded-tweet-container {
+    width: 100%;
+
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
+
+    border-radius: 0.5rem;
+
+    margin: 0.5rem 0;
+
+  }
+
+  .embedded-tweet-container__header {
+    padding: 0.5rem;
+
+    /*display: flex;*/
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .embedded-tweet-container__header img {
+    display: inline-block;
+
+    width: 2rem;
+    height: auto;
+
+    border-radius: 50%;
+  }
+
+  .embedded-tweet-container__header__userhandle,
+  .embedded-tweet-container__header__timestamp {
+    color: rgba(0, 0, 0, 0.7);
+  }
+
+  .embedded-tweet-container__body {
+    padding: 0.5rem;
+    margin: 0 1rem 0 1rem;
+  }
+
+  .embedded-tweet-container__body__image-container img {
+    max-width: 100%;
+  }
+
+  .flex {
+    /*flex: 1 1 auto;*/
+  }

--- a/twindle-cli/src/renderer/templates/github/threads-template.hbs
+++ b/twindle-cli/src/renderer/templates/github/threads-template.hbs
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  </meta>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </meta>
+  <title>Twindle thread </title>
+
+  <style type="text/css">
+    {{> style}}
+  </style>
+</head>
+
+<body>
+  {{#with threads}}
+  {{> repos-partial this}}
+  {{/with}}
+
+  <script>
+    document.onload = () => {
+      const embeddedTweetBody = document.querySelector('.embedded-tweet-container__body');
+      const anchors = embeddedTweetBody.querySelectorAll('a');
+
+      for (let a of anchors) {
+        a.onclick = e => e.preventDefault()
+      }
+    }
+  </script>
+</body>
+
+</html>

--- a/twindle-cli/src/renderer/templates/github/user-info-partial.hbs
+++ b/twindle-cli/src/renderer/templates/github/user-info-partial.hbs
@@ -1,0 +1,26 @@
+{{#if common}}
+  <div class="tweetContainer" style="page-break-before: always;">
+    <div class="header">
+      {{#if common.user}}
+      <img src="{{common.user.profile_image_url}}" alt="{{common.user.username}}" />
+      {{/if}}
+      <div>
+        {{#if common.user}}
+        <h3>
+          {{common.user.username}}
+          {{/if}}
+          <span class="user-handle">
+            <a href="https://github.com/{{common.user.username}}/{{common.repoName}}">{{common.repoName}}</a>
+          </span>
+        </h3>
+        <p>
+          <span>
+            Repository created:
+            {{common.created_at}}
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+{{/if}}
+  

--- a/twindle-cli/src/utils/date.js
+++ b/twindle-cli/src/utils/date.js
@@ -1,0 +1,11 @@
+const { format } = require("date-fns");
+
+/**
+ * Formats date into the format of `Nov 12, 2020`
+ * @param {string} timestamp
+ */
+const formatTimestamp = (timestamp) => format(new Date(timestamp), "MMM d, yyyy");
+
+module.exports = {
+  formatTimestamp,
+};


### PR DESCRIPTION
## Description
* The twindle-cli\src\index.js has been reformatted to accomodate github|hackernews as sources.
* Integration of github as a source is complete - tested with new handlebars templates and pdf generation worked
* Integration of hackernews is not done yet - will make another PR tomorrow
* Tests done:
`node . -i 1327688091642028033 -r`
`node . -u naval`
`node . -g https://github.com/Mira-Alf/twindle/blob/main/README.md`

## Changes explained
* cli.js has been modified to validate the input arguments
* All template level changes are new hbs templates for github
* render-template in pdf and epub has been modified to render the new github temolates
* Few changes made to github code written by sarvesh to accomodate some template changes and formatting date and images
* Github json structure is being written down into jsonLibrary folder for every request - I added this folder to gitignore

## Things to do
* Testing, testing and more testing to make sure these changes dont break anything that was existing
* Working on hackernews api to bring about the first round of changes
* Template designs are temporary for github - anyone wants to design better layouts, feel free to try them
* Happy path testing - I will get to this as soon as I am done with the above changes


## Attach Screenshot


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
