### PR TITLE
More changes to hackernews formatting

### DIFF
--- a/twindle-cli/.gitignore
+++ b/twindle-cli/.gitignore
@@ -2,3 +2,4 @@ TwindleLibrary
 nodemailer.config.json
 generated-mock
 jsonLibrary
+input

--- a/twindle-cli/src/github/githubparse/app.js
+++ b/twindle-cli/src/github/githubparse/app.js
@@ -11,7 +11,6 @@ async function getHtml(urlData){
     if( /[,\-]/.test(urlData)){
         dataArray.push(urlData.split(','))
     }
-    
     for(let element of dataArray[0]){
     const url =  new URL(element);
     const urlExtension = path.extname(url.pathname);
@@ -22,12 +21,14 @@ async function getHtml(urlData){
     const gituser = url.pathname.split('/')[1]
     const repoName = url.pathname.split('/')[2]
     const branch = url.pathname.split('/')[4];
+    const fileName = url.pathname.substring(url.pathname.lastIndexOf('/')+1);
     const repoURL = `https://api.github.com/repos/${gituser}/${repoName}`
     const repoResponse = {
         common : await jsonfetchData(repoURL),
         htmlValue : await convertHTML(element)
     };
     repoResponse.common.branch = branch;
+    repoResponse.common.fileName = fileName;
 
     data.push(repoResponse);
     

--- a/twindle-cli/src/hacker-news/code.js
+++ b/twindle-cli/src/hacker-news/code.js
@@ -1,3 +1,4 @@
+var cheerio = require('cheerio')
 const fetch = require("node-fetch");
 const { formatTimestamp } = require("../utils/date");
 
@@ -10,7 +11,7 @@ async function fetchItem(url) {
     return result;
 }
 
-async function getStories(storyId, numCommentLevels) {
+async function getStories(storyId, numTopComments, numCommentLevels) {
     let ids = storyId.split(",");
     let stories = [];
     const requests = ids.map((id) => 
@@ -19,25 +20,42 @@ async function getStories(storyId, numCommentLevels) {
     const filter = await Promise.all(response.map((res) => res.json()));
     for(let result of filter) {
         const story = await getStoryObject(result);
-        await appendComments(story, 1, numCommentLevels);
+        await appendComments(story, numTopComments, 1, numCommentLevels);
         stories.push(story);
     }
     return stories;
 }
 
-async function appendComments(parent, iterationLevel, numCommentLevels) {
-    if((iterationLevel <= numCommentLevels) && parent.kids) {
-        const requests = parent.kids.map((id) => 
-            fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json?print=pretty`));
-        const response = await Promise.all(requests);
-        const filter = await Promise.all(response.map((res) => res.json()));
-        for(let result of filter) {
+async function appendComments(parent, numTopComments, iterationLevel, numCommentLevels) {
+    if((iterationLevel <= numCommentLevels) && parent.kids && parent.kids.length > 0) {
+        const filter = await getCommentResponses(parent, numTopComments);
+        for(let result of filter) {            
             let comment = await getCommentObject(result, iterationLevel);            
-            comment = await appendComments(comment, iterationLevel+1, numCommentLevels);
+            comment = await appendComments(comment, numTopComments, iterationLevel+1, numCommentLevels);
+            comment.index = parent.comments.length;
             parent.comments.push(comment);
         }        
     }
     return parent;
+}
+
+async function getCommentResponses(parent, numTopComments) {
+    if(parent.kids.length > 0) {
+        const kids = parent.kids.length <= numTopComments ? parent.kids : parent.kids.slice(0, numTopComments);
+        const requests = kids.map((id) => 
+            fetch(`https://hacker-news.firebaseio.com/v0/item/${id}.json?print=pretty`));
+        kids.forEach(k=>parent.kids.pop(k));
+        const response = await Promise.all(requests);
+        let filter = await Promise.all(response.map((res) => res.json()));
+        filter = filter.filter(result=>!result.deleted);
+        if(filter.length == numTopComments || parent.kids.length == 0)
+            return filter;
+        else {
+            let newFilter = await getCommentResponses(parent, numTopComments-filter.length);
+            newFilter.forEach(result=>filter.push(result));
+            return newFilter;
+        }
+    }
 }
 
 async function getStoryObject(result) {
@@ -47,6 +65,19 @@ async function getStoryObject(result) {
     story.common.created_at = formatTimestamp(new Date(result.time * 1000));
     story.common.title = result.title;
     story.common.url = result.url;
+    const response = await fetch(result.url);
+    const responseText = await response.text();
+    var $ = cheerio.load(responseText);
+    var title = $('meta[property="og:title"]').attr('content');
+    if(!title)
+        title = $('title').attr('content');
+    story.common.siteTitle = title;
+    var image = $('meta[property="og:image"]').attr('content');
+    if(!image)
+        image = $('image').attr('content');
+    if(!image)
+        image = 'https://news.ycombinator.com/favicon.ico';
+    story.common.image = image;
     story.common.user = await getUser(result.by);
     story.common.numComments = result.descendants;
     story.common.score = result.score;

--- a/twindle-cli/src/index.js
+++ b/twindle-cli/src/index.js
@@ -17,7 +17,7 @@ async function main() {
   try {
     prepareCli();
     spinner.start();
-    let cliObject = getCommandLineObject();
+    let cliObject = await getCommandLineObject();
     //console.log(cliObject);
     const data = await getDataFromSource(cliObject);
     //console.log(JSON.stringify(data));
@@ -100,8 +100,8 @@ async function getDataFromGithub({githubURL}) {
   return await getHtml(githubURL);
 }
 
-async function getDataFromHackernews({storyId, numCommentLevels}) {
-  return await getStories(storyId, numCommentLevels);
+async function getDataFromHackernews({storyId, numTopComments, numCommentLevels}) {
+  return await getStories(storyId, numTopComments, numCommentLevels);
 }
 
 function calculateFileName(cliObject, data) {
@@ -150,9 +150,14 @@ function calculateFileNameForGitHub(cliObject, data) {
     data[0].common &&
     data[0].common.repoName
   );
+  let fileName = (
+    data[0] &&
+    data[0].common &&
+    data[0].common.fileName
+  );
   let date = new Date();
   date = formatTimestamp(date).replace(/,/g, "").replace(/ /g, "-");
-  return calculateGenericFileName(cliObject, `${username}-${repoName}`, date);
+  return calculateGenericFileName(cliObject, `${username}-${repoName}-${fileName}`, date);
 }
 
 function calculateFileNameForHackernews(cliObject, data) {
@@ -166,7 +171,7 @@ function calculateFileNameForHackernews(cliObject, data) {
     data[0] &&
     data[0].common &&
     data[0].common.title
-  ).replace(/,/g, "").replace(/ /g, "-").substring(0, 10);
+  ).replace(/\W/g, "-").substring(0, 10);
   let date = (data[0] &&  
     data[0].common &&
     data[0].common.created_at.replace(/,/g, "").replace(/ /g, "-"));

--- a/twindle-cli/src/renderer/epub/render-template.js
+++ b/twindle-cli/src/renderer/epub/render-template.js
@@ -123,8 +123,11 @@ async function renderHackernewsTemplate(data) {
   const commentHtml = await readFile(`${__dirname}/../templates/hackernews/comment-partial.hbs`, "utf-8");
   hbs.registerPartial('common-info-partial', commonInfoHtml);
   hbs.registerPartial('comment-partial', commentHtml);
-  hbs.registerHelper('levelcalculator', function (level) {
-    return (level-1)*50;
+  hbs.registerHelper('levelcalculator', function (comment) {
+    if(comment.level-1 == 0 && comment.index != 0 && comment.comments.length > 0)
+      return "style='page-break-before:always'";
+    else
+      return "";
   });
 
   const articlesTemplate = hbs.compile(articlesHtml, {

--- a/twindle-cli/src/renderer/pdf/render-template.js
+++ b/twindle-cli/src/renderer/pdf/render-template.js
@@ -83,8 +83,11 @@ async function renderHackernewsTemplate(data) {
   hbs.registerPartial('common-info-partial', commonInfoHtml);
   hbs.registerPartial('comment-partial', commentHtml);
   hbs.registerPartial('style', css);
-  hbs.registerHelper('levelcalculator', function (level) {
-    return (level-1)*50;
+  hbs.registerHelper('levelcalculator', function (comment) {
+    if(comment.level-1 == 0 && comment.index != 0 && comment.comments.length > 0)
+      return "style='page-break-before:always'";
+    else
+      return "";
   });
   
   // creates the Handlebars template object

--- a/twindle-cli/src/renderer/templates/hackernews/articles-partial.hbs
+++ b/twindle-cli/src/renderer/templates/hackernews/articles-partial.hbs
@@ -1,12 +1,14 @@
 {{#each this}}
-  {{> common-info-partial this }}
-  <ul>
-    {{#if comments}}
-      {{#each comments}}
-        <li>
+{{> common-info-partial this }}
+  <div id="w">
+    <div id="container">    
+      {{#if comments}}
+      <ul id="comments">    
+        {{#each comments}}
           {{> comment-partial this}}
-        </li>
-      {{/each}}
-    {{/if}}
-  </ul>
+        {{/each}}
+      </ul>
+      {{/if}}
+    </div>
+  </div>
   {{/each}}

--- a/twindle-cli/src/renderer/templates/hackernews/comment-partial.hbs
+++ b/twindle-cli/src/renderer/templates/hackernews/comment-partial.hbs
@@ -1,27 +1,15 @@
-<section class="embedded-tweet-container" style="text-indent: {{levelcalculator level}}px">
-    <div class="embedded-tweet-container__header">
-        <a href="https://news.ycombinator.com/user?id={{username}}">
-            <span class="embedded-tweet-container__header__name">
-            <b>
-                {{username}}
-            </b>
-            </span>
-        </a>
-        <span class="flex"></span>
-        {{#if created_at}}
-            <span class="embedded-tweet-container__header__timestamp">
-                {{created_at}}
-            </span>
-        {{/if}}
+<div {{{levelcalculator this}}}>
+<li class="cmmnt">
+    <div class="cmmnt-content">
+    <header><a href="javascript:void(0);" class="userlink">{{username}}</a> - <span class="pubdate">{{created_at}}</span></header>
+    <p>{{{text}}}</p>
     </div>
-    <div class="embedded-tweet-container__body">
-        {{{text}}}
-    </div>
-</section>
-{{#if comments}}
-    {{#each comments}}
-    <li>
-        {{> comment-partial this}}
-    </li>
-    {{/each}}
-{{/if}}
+    {{#if comments}}
+        <ul class="replies">
+            {{#each comments}}
+                {{> comment-partial this}}
+            {{/each}}    
+        </ul>
+    {{/if}}    
+</li>
+</div>

--- a/twindle-cli/src/renderer/templates/hackernews/common-info-partial.hbs
+++ b/twindle-cli/src/renderer/templates/hackernews/common-info-partial.hbs
@@ -1,46 +1,18 @@
 {{#if common}}
-  <div class="tweetContainer" style="page-break-before: always;">
-    <div class="header">
-      <div>
-        {{#if common.user}}
-        <h3>
-          <span class="user-handle">
-            <a href="https://news.ycombinator.com/user?id={{common.user.username}}">{{common.user.username}}</a>
-          </span>
-        </h3>
-        {{/if}}
-        <p>
-          <span>
-            Title:
-            <a href="https://news.ycombinator.com/item?id={{common.id}}">{{common.title}}</a>
-          </span>
-        </p>
-        <p>
-          <span>
-            Link:
-            <a href="{{common.url}}">Original article</a>
-          </span>
-        </p>
-        <p>
-          <span>
-            Entry created:
-            {{common.created_at}}
-          </span>
-        </p>
-        <p>
-          <span>
-            Number of comments:
-            {{common.numComments}}
-          </span>
-        </p>
-        <p>
-          <span>
-            Story rating:
-            {{common.score}}
-          </span>
-        </p>
-      </div>
+  <div id="common-info">
+    <div class="article-info clearfix">
+      <img alt="" src="{{common.image}}" class="avatar avatar-114 photo" width="114" height="114">
+      <div class="article-info-content">
+        <h2 class="article-name">
+          <a href="{{common.url}}">{{common.title}}</a>
+        </h2>
+        <h3 class="article-name">{{common.created_at}}</h3>        
     </div>
-  </div>
+    <div class="author-bio-text">
+      <a data-title="user-name" href="https://news.ycombinator.com/user?id={{common.user.username}}">{{common.user.username}}</a>
+      <span style="float:right">&#8618;{{common.numComments}}</span>
+      <span style="padding-left:20px">&#9733;{{common.score}}</span>
+    </div>
+  </div>  
 {{/if}}
   

--- a/twindle-cli/src/renderer/templates/hackernews/style.css
+++ b/twindle-cli/src/renderer/templates/hackernews/style.css
@@ -1,246 +1,158 @@
-* {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
-    "Open Sans", "Helvetica Neue", sans-serif;
+html, body, div, span, applet, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, acronym, address, big, cite, code, del, dfn, em, img, ins, kbd, q, s, samp, small, strike, strong, sub, sup, tt, var, b, u, i, center, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, embed, figure, figcaption, footer, header, hgroup, menu, nav, output, ruby, section, summary, time, mark, audio, video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
+  outline: none;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
 }
-body {
-  margin: 10px 10px 20px 10px;
-  font-size: 108%;
+html { height: 101%; }
+body { /*background: #e3e0ef url('images/bg.png');*/ font-size: 62.5%; line-height: 1; font-family: Arial, sans-serif; padding-bottom: 65px; }
+
+::selection { background: #d7d0f3; }
+::-moz-selection { background: #d7d0f3; }
+::-webkit-selection { background: #d7d0f3; }
+
+article, aside, details, figcaption, figure, footer, header, hgroup, menu, nav, section { display: block; }
+ol, ul { list-style: none; }
+
+blockquote, q { quotes: none; }
+blockquote:before, blockquote:after, q:before, q:after { content: ''; content: none; }
+strong { font-weight: bold; } 
+
+table { border-collapse: collapse; border-spacing: 0; }
+img { border: 0; max-width: 100%; }
+
+h1 { font-family: 'Wellfleet', 'Trebuchet MS', Tahoma, Arial, sans-serif; font-size: 2.85em; line-height: 1.6em; font-weight: normal; color: #756f8b; text-shadow: 0px 1px 1px #fff; margin-bottom: 21px; }
+
+p { font-family: Arial, Geneva, Verdana, sans-serif; font-size: 1.3em; line-height: 1.42em; margin-bottom: 12px; font-weight: normal; color: #656565; }
+
+a { color: #896dc6; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+#common-info{
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 700px;
+  max-width: 720px;
 }
 
-a[href] {
-  text-decoration: none !important;
+.article-info {
+  margin: 20px auto 10px;
+  padding: 40px 30px;
+  background: #191c1d;
+  color: #fff;
 }
 
-a[href]:not(.link-box-anchor):not(.embedded-tweet-anchor) {
-  color: rgb(29, 161, 242);
+.article-info .avatar {
+  vertical-align: middle;
+  -webkit-border-radius: 50%;
+  -moz-border-radius: 50%;
+  border-radius: 10%;
+  float: left;
+}
+
+.article-info-content {
+  margin-left: 135px;
+}
+
+.clearfix::after {
+  display: block;
+  content: "";
+  clear: both;
+}
+
+.article-name {
+  margin-top: 0;
+  font-size: 24px;
+  padding-top: 0;
+  padding-bottom: 15px;
+  text-transform: uppercase;
+}
+
+.article-date a {
+  color: #f8b147;
+}
+
+.author-bio-text {
+  font-size: 16px;
+  line-height: 24px;
+  float: left;
+  width: 100%;
+  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  padding-top: 20px;
+}
+
+.author-bio-text a, .author-bio-text a:hover {
+  color: #f8b147;
   text-decoration: none;
-  background-image: linear-gradient(
-    transparent 0%,
-    transparent 35%,
-    rgba(29, 161, 242, 0.3) 35%,
-    rgba(29, 161, 242, 0.3) 100%
-  );
-  background-size: 100% 200%;
-  background-position: 0px 0px;
-  word-break: break-word;
-}
-
-#title {
-  text-align: center;
-}
-
-ul {
-  list-style-type: none;
-
-  /*display: flex;*/
-  align-items: center;
-  justify-content: stretch;
-  /*flex-direction: column;*/
-  padding: 0;
-}
-
-ul li {
-  margin: 0;
-
-  width: 100%;
-
-  padding: 1rem 0;
-}
-
-ul li:not(:last-child) {
-  border-bottom: solid 1px rgba(0, 0, 0, 0.3);
-}
-
-.tweetContainer {
-  /*display: flex;
-  flex-direction: column;*/
-  width: 100%;
-}
-
-.tweetContainer * {
-  margin: 0;
-  padding: 0;
-}
-
-.tweetContainer a.media-link {
-  width: 100%;
-}
-
-.tweetContainer .tweet-img {
-  margin: 10px 0;
-
-  border-radius: 0.5rem;
-
-  max-width: 100%;
-  height: auto;
-}
-
-.tweetContainer .header {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.tweetContainer .header img {
-  max-width: 75px;
-  border-radius: 50%;
-  margin-right: 10px;
-}
-
-.tweetContainer .header > div {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-}
-
-.tweetContainer .header > div p {
-  font-size: 14px;
-}
-
-.tweetContainer .header > div span {
-  font-style: italic;
-  color: rgb(45, 45, 45);
-}
-
-img.emoji,
-.verified-badge {
-  height: 1em;
-  width: 1em;
-  margin: 0 0.05em 0 0.1em;
-  vertical-align: -0.1em;
-}
-
-.user-handle {
-  color: rgba(0, 0, 0, 0.5) !important;
-}
-
-.link-box-anchor {
-  width: 100%;
-}
-
-.link-box {
-  width: 100%;
-  height: 135px;
-
-  margin: 10px 0;
-
-  border-radius: 0.5rem;
-
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);
-
-  background-color: rgba(0, 0, 0, 0.06);
-
-  /*display: flex;*/
-}
-
-.link-box .link-img-container {
-  height: 100%;
-
-  border-radius: 0.5rem 0 0 0.5rem;
-}
-
-.link-box .link-img-container img {
-  border-radius: inherit;
-
-  height: 100%;
-  width: auto;
-}
-
-.link-box > .link-box-content {
-  /*flex: 1;*/
-
-  color: initial;
-
   position: relative;
-
-  padding: 5px 0;
-  padding-left: 0.5rem;
-
-  /*display: flex;
-    flex-direction: column;*/
-  justify-content: space-between;
+  white-space: nowrap;
 }
 
-.link-box-content-heading,
-.link-box-content-description,
-.link-box-content-domain {
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-
-  font-size: 0.95rem;
+.author-bio-text a::after {
+  background: #f8b147;
 }
 
-.link-box-content-description,
-.link-box-content-domain {
-  color: rgba(0, 0, 0, 0.7);
-  font-size: 0.85rem;
+.author-bio-text a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 1px;
+  background: #fcbc3e;
+  width: 0;
 }
 
-.link-box-content-domain {
-  /*display: flex;*/
-  align-items: center;
+/* page layout structure */ 
+#w { display: block; width: 700px; margin: 0 auto; padding-top: 35px; }
+
+#container { 
+  display: block; 
+  width: 100%; 
+  background: #fff; 
+  padding: 14px 20px; 
+  -webkit-border-radius: 4px; 
+  -moz-border-radius: 4px; 
+  border-radius: 4px; 
+  -webkit-box-shadow: 1px 1px 1px rgba(0,0,0,0.3);
+  -moz-box-shadow: 1px 1px 1px rgba(0,0,0,0.3);
+  box-shadow: 1px 1px 1px rgba(0,0,0,0.3);
 }
 
-.link-box-content-domain .link-svg {
-  width: 0.9rem;
-  fill: rgba(0, 0, 0, 0.7);
 
-  margin-right: 0.5rem;
+/* comments area */
+#comments { display: block; }
+
+#comments .cmmnt, ul .cmmnt, ul ul .cmmnt { display: block; position: relative; padding-left: 35px; border-top: 1px solid #ddd; }
+
+#comments .cmmnt .avatar  { position: absolute; top: 8px; left: 0; }
+#comments .cmmnt .avatar img { 
+  -webkit-border-radius: 3px; 
+  -moz-border-radius: 3px; 
+  border-radius: 3px; 
+  -webkit-box-shadow: 1px 1px 2px rgba(0,0,0,0.44);
+  -moz-box-shadow: 1px 1px 2px rgba(0,0,0,0.44);
+  box-shadow: 1px 1px 2px rgba(0,0,0,0.44);
+  -webkit-transition: all 0.4s linear;
+  -moz-transition: all 0.4s linear;
+  -ms-transition: all 0.4s linear;
+  -o-transition: all 0.4s linear;
+  transition: all 0.4s linear;
 }
 
-.embedded-tweet-anchor {
-  color: rgba(0, 0, 0, 0.9) !important;
-  font-size: 1rem;
-}
+#comments .cmmnt .avatar a:hover img { opacity: 0.77; }
 
-.embedded-tweet-container {
-  width: 100%;
+#comments .cmmnt .cmmnt-content { padding: 0px 3px; padding-bottom: 12px; padding-top: 8px; }
 
-  /*box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3);*/
+#comments .cmmnt .cmmnt-content header { font-size: 1.3em; display: block; margin-bottom: 8px; }
+#comments .cmmnt .cmmnt-content header .pubdate { color: #777; }
+#comments .cmmnt .cmmnt-content header .userlink { font-weight: bold; } 
 
-  border-radius: 0.5rem;
-
-  margin: 0.5rem 0;
-}
-
-.embedded-tweet-container__header {
-  padding: 0.5rem;
-
-  /*display: flex;*/
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.embedded-tweet-container__header img {
-  display: inline-block;
-
-  width: 2rem;
-  height: auto;
-
-  border-radius: 50%;
-}
-
-.embedded-tweet-container__header__userhandle,
-.embedded-tweet-container__header__timestamp {
-  color: rgba(0, 0, 0, 0.7);
-}
-
-.embedded-tweet-container__body {
-  padding: 0.5rem;
-  margin: 0 1rem 0 1rem;
-}
-
-.embedded-tweet-container__body__image-container img {
-  max-width: 100%;
-}
-
-.flex {
-  /*flex: 1 1 auto;*/
-}
-
-img {
-  max-width: 100%;
-}
+#comments .cmmnt .replies { margin-bottom: 7px; }

--- a/twindle-cli/src/renderer/templates/hackernews/threads-template.hbs
+++ b/twindle-cli/src/renderer/templates/hackernews/threads-template.hbs
@@ -11,23 +11,14 @@
   <style type="text/css">
     {{> style}}
   </style>
+  <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Wellfleet">
 </head>
 
 <body>
   {{#with threads}}
-  {{> articles-partial this}}
+    {{> articles-partial this}}
   {{/with}}
 
-  <script>
-    document.onload = () => {
-      const embeddedTweetBody = document.querySelector('.embedded-tweet-container__body');
-      const anchors = embeddedTweetBody.querySelectorAll('a');
-
-      for (let a of anchors) {
-        a.onclick = e => e.preventDefault()
-      }
-    }
-  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Description
* As per issue #892 and #895, A new template has been designed for the title section and comments of the hackernews article
[This page](https://www.webdesignerdepot.com/cdn-origin/uploads7/building-a-threaded-comment-block-with-html5-and-css3/demo/) has been used as inspiration
* As per issue #893 and #894, hackernews pdf can be generated using this command:
`node . -h 25319539 -t 10 -d 3`
where h is the hackernews id, t number of top level comments and d is the number of levels of comments to be extracted. Couldnt reuse n as it is used for twitter
* Fixes for github issues #879, #889 and #890 are present in this commit

## Things to do
* Testing this extensively is needed
* Anyone can pick up the template layout of the hackernews article and change it as they want. I am done with it. I dont want to make any more changes there. :(
* Some more refactoring might be needed now that we have expanded the scope of the project. Discussion with kenny and others might be needed.




## Attach Screenshot


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
