### PR TITLE
If article parsing fails, then throw an error - fix for #949

### DIFF
--- a/twindle-cli/src/readability/index.js
+++ b/twindle-cli/src/readability/index.js
@@ -1,6 +1,7 @@
 const { Readability } = require("@mozilla/readability");
 const image = require("../utils/image");
 const JSDOM = require("jsdom").JSDOM;
+const { UserError } = require("../helpers/error")
 
 async function readURL(testUrl) {
   let urls = testUrl.split(",");
@@ -8,6 +9,11 @@ async function readURL(testUrl) {
   for (let url of urls) {
     let windowDocument = await getJSDOM(url);
     let article = getParsedArticle(windowDocument);
+    if(article === null)
+      throw new UserError(
+        "mozilla-readability-error",
+        "Failed to load article from page"
+      );
     threads.push(getArticleJSON(article, url, windowDocument));
   }
   return threads;


### PR DESCRIPTION
## Description
* Some urls are not being rendered correctly because their html is not well formed for the mozilla readability app to clean up as a result the parsing of the page using jsdom to an article fails, in such cases, throw an error and fail gracefully
* This can be a temporary fix until something better comes along.




## Attach Screenshot


> Note 2 code reviewer approval needed. Approach in twitter group & discord channel.
